### PR TITLE
Allow plugin forms them to modify the config object before submit

### DIFF
--- a/src/ui/widgets/config/WidgetConfigForm.js
+++ b/src/ui/widgets/config/WidgetConfigForm.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { reduxForm } from 'redux-form';
 import pluginArray from 'entando-plugins';
 import InternalServletConfigForm from 'ui/widgets/config/forms/InternalServletConfigForm';
 
@@ -32,9 +31,4 @@ WidgetConfigFormBody.propTypes = {
   onSubmit: PropTypes.func.isRequired,
 };
 
-const WrappedWidgetConfigForm = reduxForm({
-  form: 'widgetConfigForm',
-})(WidgetConfigFormBody);
-
-
-export default WrappedWidgetConfigForm;
+export default WidgetConfigFormBody;

--- a/src/ui/widgets/config/forms/InternalServletConfigForm.js
+++ b/src/ui/widgets/config/forms/InternalServletConfigForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Field } from 'redux-form';
+import { Field, reduxForm } from 'redux-form';
 import { FormattedMessage } from 'react-intl';
 import { formattedText } from '@entando/utils';
 import { Row, Col, FormGroup, Button } from 'patternfly-react';
@@ -58,4 +58,6 @@ InternalServletConfigForm.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
 };
 
-export default InternalServletConfigForm;
+export default reduxForm({
+  form: 'widgetConfigForm',
+})(InternalServletConfigForm);

--- a/src/ui/widgets/config/forms/InternalServletConfigForm.js
+++ b/src/ui/widgets/config/forms/InternalServletConfigForm.js
@@ -7,7 +7,7 @@ import { Row, Col, FormGroup, Button } from 'patternfly-react';
 import FormLabel from 'ui/common/form/FormLabel';
 
 
-const InternalServletConfigForm = ({ handleSubmit }) => (
+export const InternalServletConfigFormBody = ({ handleSubmit }) => (
   <form
     className="InternalServletConfigForm"
     onSubmit={(ev) => { ev.preventDefault(); handleSubmit(); }}
@@ -54,10 +54,10 @@ const InternalServletConfigForm = ({ handleSubmit }) => (
 );
 
 
-InternalServletConfigForm.propTypes = {
+InternalServletConfigFormBody.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
 };
 
 export default reduxForm({
   form: 'widgetConfigForm',
-})(InternalServletConfigForm);
+})(InternalServletConfigFormBody);

--- a/test/test/mocks/widgets.js
+++ b/test/test/mocks/widgets.js
@@ -46,6 +46,14 @@ export const WIDGET_LIST = {
       used: 1,
       hasConfig: true,
     },
+    {
+      ...WIDGET,
+      code: 'bpm-case-progress-status',
+      typology: 'Entando Redhat BPM connector',
+      titles: { it: 'BPM-Case progress status', en: 'BPM-Case progress status' },
+      used: 1,
+      hasConfig: true,
+    },
   ],
   errors: [],
   metaData: {

--- a/test/ui/widgets/config/WidgetConfigForm.test.js
+++ b/test/ui/widgets/config/WidgetConfigForm.test.js
@@ -15,17 +15,6 @@ describe('WidgetConfigForm', () => {
     jest.clearAllMocks();
   });
 
-  it('if widgetId = "formAction", wraps an InternalServletConfigForm', () => {
-    component = shallow((
-      <WidgetConfigFormBody
-        {...PROPS}
-        widgetId="formAction"
-      />
-    ));
-    expect(component.is('InternalServletConfigForm')).toBe(true);
-    expect(component.props()).toEqual({ ...PROPS, widgetId: 'formAction' });
-  });
-
   it('if widgetId is coming from a plugin', () => {
     component = shallow((
       <WidgetConfigFormBody

--- a/test/ui/widgets/config/forms/InternalServletConfigForm.test.js
+++ b/test/ui/widgets/config/forms/InternalServletConfigForm.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import InternalServletConfigForm from 'ui/widgets/config/forms/InternalServletConfigForm';
+import { InternalServletConfigFormBody } from 'ui/widgets/config/forms/InternalServletConfigForm';
 
 const handleSubmit = jest.fn();
 const EVENT = { preventDefault: jest.fn() };
@@ -12,7 +12,7 @@ describe('InternalServletConfigForm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     component = shallow((
-      <InternalServletConfigForm
+      <InternalServletConfigFormBody
         widgetId="formAction"
         handleSubmit={handleSubmit}
       />

--- a/test/ui/widgets/list/WidgetListTable.test.js
+++ b/test/ui/widgets/list/WidgetListTable.test.js
@@ -33,7 +33,7 @@ describe('WidgetListTable', () => {
 
   it('renders five WidgetListRow', () => {
     expect(component.find(WidgetListRow).exists()).toBe(true);
-    expect(component.find(WidgetListRow)).toHaveLength(6);
+    expect(component.find(WidgetListRow)).toHaveLength(7);
   });
 
   it('not renders  WidgetListRow', () => {


### PR DESCRIPTION
To be merged **before** the following PR: https://github.com/entando/entando-components/pull/239

Force plugin forms to wrap the forms with reduxForm themselves, in order to allow them to modify the config object before submit