### PR TITLE
[5.0.1] EN-1584-501-profiles-types-edit-attribute-code-not-editable

### DIFF
--- a/src/ui/common/form/EditAttributeForm.js
+++ b/src/ui/common/form/EditAttributeForm.js
@@ -95,7 +95,7 @@ export class EditAttributeFormBody extends Component {
         <Row>
           <Col xs={12}>
             <fieldset className="no-padding">
-              <AttributeInfo {...this.props} />
+              <AttributeInfo {...this.props} mode="edit" />
               <AttributeRole {...this.props} />
               {renderMonolistConf()}
               {renderTextConf()}

--- a/src/ui/pages/common/PageForm.js
+++ b/src/ui/pages/common/PageForm.js
@@ -25,7 +25,7 @@ export class PageFormBody extends Component {
   render() {
     const {
       handleSubmit, invalid, submitting, selectedJoinGroups, groups, pageModels,
-      contentTypes, charsets, mode, onChangeEnTitle, parentCode, parentTitle, // locale,
+      contentTypes, charsets, mode, onChangeEnTitle, parentCode, parentTitle,
     } = this.props;
 
     const isEditMode = mode === 'edit';


### PR DESCRIPTION
Code readonly for profile type attributes in edit mode and removed comment in PageForm