### PR TITLE
Changes for All-in-one Entando bundle - second attempt

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ a boolean used to determine whether the API calls will be against a real Entando
 a string representing the domain name of the Entando Core instance. The protocol is optional and it is possible to specify a subdirectory of the domain.
 Trailing slashes are not valid and it only vaildates up to 3rd level domains.
 
+#### `EMBEDDED_DOMAIN` (optional, string, default: `null`)
+a string representing the context that the Entando Core is running which is relative to the base URL of the App Builder. The `DOMAIN` property is ignored when `EMBEDDED_DOMAIN` is provided.  This allows the same deployment of Entando Core and App Builder to be bundled and deployed together anywhere without rebuilding the App Builder each time as long as the relative context is consistent.
+
+#### `PUBLIC_URL` (optional, string, default: `null`)
+this is a standard react property that you "may use ... to force assets to be referenced verbatim to the url you provide".  This value should be used when the App Builder is not being deployed to the root context (e.g., `/appbuilder`).  This value will be prepended to all routes as well as calls that request static resources within the project.
+
 All the following would be valid values:
 
 - http://my.entando.com
@@ -27,12 +33,29 @@ All the following would be valid values:
 - //my.entando.com
 - //my.entando.com/entando-sample
 
-### Sample .env file
+### Sample .env file: deploying separately from Entando Core
 
 ```
 USE_MOCKS=false
 DOMAIN=//my.entando.com
 ```
+
+### Sample .env file: deploying bundled with Entando Core
+
+```
+USE_MOCKS=false
+PUBLIC_URL=/appbuilder
+EMBEDDED_DOMAIN=entando
+```
+* Using the above compile-time configuration would result in an App Builder working as follows:
+  * Deployed to http://myserver.com:8080
+    * App Builder: http://myserver.com:8080/appbuilder
+    * Entando Core: http://myserver.com:8080/entando
+  * Deployed to https://192.168.1.1
+    * App Builder: https://192.168.1.1/appbuilder
+    * Entando Core: https://192.168.1.1/entando
+  * etc.
+
 ---
 
 ## Commands

--- a/config/env.js
+++ b/config/env.js
@@ -79,6 +79,7 @@ function getClientEnvironment(publicUrl) {
         PUBLIC_URL: publicUrl,
         USE_MOCKS: process.env.USE_MOCKS !== 'false',
         DOMAIN: process.env.DOMAIN || null,
+        EMBEDDED_DOMAIN: process.env.EMBEDDED_DOMAIN || null,
       }
     );
   // Stringify all values so we can feed into Webpack DefinePlugin

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@entando/apimanager": "^2.0.1",
     "@entando/messages": "^1.0.1",
-    "@entando/router": "^1.0.2",
+    "@entando/router": "^1.0.4",
     "@entando/utils": "^1.0.6",
     "autoprefixer": "7.1.6",
     "babel-core": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@entando/apimanager": "^2.0.1",
     "@entando/messages": "^1.0.1",
-    "@entando/router": "^1.0.4",
+    "@entando/router": "^1.1.0",
     "@entando/utils": "^1.0.6",
     "autoprefixer": "7.1.6",
     "babel-core": "6.26.0",

--- a/src/app-init/apiManager.js
+++ b/src/app-init/apiManager.js
@@ -7,8 +7,13 @@ import { ROUTE_HOME, ROUTE_DASHBOARD } from 'app-init/router';
 import pluginsArray from 'entando-plugins';
 
 config(store, ROUTE_HOME, ROUTE_DASHBOARD);
+let parsedDomain = process.env.DOMAIN;
+const embeddedDomain = process.env.EMBEDDED_DOMAIN;
+if (embeddedDomain) {
+  parsedDomain = `${window.location.origin}/${embeddedDomain}`;
+}
 store.dispatch(setApi({
-  domain: process.env.DOMAIN,
+  domain: parsedDomain,
   useMocks: process.env.USE_MOCKS,
 }));
 

--- a/src/app-init/apiManager.js
+++ b/src/app-init/apiManager.js
@@ -7,13 +7,10 @@ import { ROUTE_HOME, ROUTE_DASHBOARD } from 'app-init/router';
 import pluginsArray from 'entando-plugins';
 
 config(store, ROUTE_HOME, ROUTE_DASHBOARD);
-let parsedDomain = process.env.DOMAIN;
-const embeddedDomain = process.env.EMBEDDED_DOMAIN;
-if (embeddedDomain) {
-  parsedDomain = `${window.location.origin}/${embeddedDomain}`;
-}
 store.dispatch(setApi({
-  domain: parsedDomain,
+  domain: process.env.EMBEDDED_DOMAIN ?
+    `${window.location.origin}/${process.env.EMBEDDED_DOMAIN}` :
+    process.env.DOMAIN,
   useMocks: process.env.USE_MOCKS,
 }));
 

--- a/src/app-init/router.js
+++ b/src/app-init/router.js
@@ -82,7 +82,7 @@ routerConfig(
   store,
   {
     mode: 'browser',
-    pathPrefix: `${process.env.PUBLIC_URL}`,
+    pathPrefix: process.env.PUBLIC_URL,
     routes: [
       { name: ROUTE_HOME, path: '/' },
       { name: ROUTE_DASHBOARD, path: '/dashboard' },

--- a/src/app-init/router.js
+++ b/src/app-init/router.js
@@ -82,6 +82,7 @@ routerConfig(
   store,
   {
     mode: 'browser',
+    pathPrefix: `${process.env.PUBLIC_URL}`,
     routes: [
       { name: ROUTE_HOME, path: '/' },
       { name: ROUTE_DASHBOARD, path: '/dashboard' },


### PR DESCRIPTION
This PR replaces (https://github.com/entando/app-builder/pull/401) and uses the suggestions in the discussion for the 5.0.0 based attempt.  

2 goals:

1. Allow AppBuilder to run in subcontext.   This relies on changes made to the router in Entando front-end components which introduces an optional pathPrefix configuration parameter.  This code change is in PR (https://github.com/entando/frontend-libraries/pull/19).

The changes here leverage the PUBLIC_URL env variable and is explained in the readme

2. Allow AppBuilder to refer to an instance of the Entando Core which is deployed in a relative context.  The name of that context is set using the env variable EMBEDDED_DOMAIN.  This is also covered in the updated readme