### PR TITLE
EN-2282 - amend toolbar buttons in Page Configuration

### DIFF
--- a/sass/pages/config/PageConfigPage.scss
+++ b/sass/pages/config/PageConfigPage.scss
@@ -1,15 +1,62 @@
 .PageConfigPage {
   &__title {
-    font-weight: bold;
+    color: $color-pf-blue-300;
+    font-size: 12px;
+    font-weight: normal;
   }
 
   &__toolbar-row {
     margin-bottom: 5px;
   }
 
-  &__settings-btn {
+  &__trans-btns {
+    padding-bottom: 5px;
+
+    .btn { // sass-lint:disable-line force-element-nesting class-name-format
+      border: 0;
+      outline: none;
+      background: transparent;
+      box-shadow: none;
+
+      &:hover, // sass-lint:disable-line nesting-depth
+      &:active {
+        color: $color-pf-blue-300;
+      }
+    }
+
+    .further .btn { // sass-lint:disable-line force-element-nesting class-name-format
+      margin-left: 36px;
+    }
+  }
+
+  &__icon-btn {
+    span .fa { // sass-lint:disable-line force-element-nesting class-name-format
+      padding-right: 8px;
+    }
+  }
+
+  &__icon-btn-right {
     span .fa { // sass-lint:disable-line force-element-nesting class-name-format
       padding-left: 8px;
+    }
+  }
+
+  &__bottom-options {
+    position: fixed;
+    right: 67px;
+    bottom: 5px;
+    left: 5px;
+    z-index: 11;
+
+    .pull-right .btn:not(.dropdown-toggle) { // sass-lint:disable-line force-element-nesting class-name-format
+      margin-left: 20px;
+    }
+
+    .tbar { // sass-lint:disable-line force-element-nesting class-name-format
+      margin: 0 20px;
+      padding: 8px 14px;
+      background-color: $color-pf-white;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, .25);
     }
   }
 

--- a/sass/pages/config/PageConfigPage.scss
+++ b/sass/pages/config/PageConfigPage.scss
@@ -9,36 +9,38 @@
     margin-bottom: 5px;
   }
 
-  &__trans-btns {
+  &__btn-group--trans {
     padding-bottom: 5px;
 
-    .btn { // sass-lint:disable-line force-element-nesting class-name-format
-      border: 0;
-      outline: none;
-      background: transparent;
-      box-shadow: none;
-
-      &:hover, // sass-lint:disable-line nesting-depth
-      &:active {
-        color: $color-pf-blue-300;
-      }
-    }
-
-    .further .btn { // sass-lint:disable-line force-element-nesting class-name-format
+    .pull-right .btn {  // sass-lint:disable-line force-element-nesting class-name-format
       margin-left: 36px;
     }
   }
 
-  &__icon-btn {
-    span .fa { // sass-lint:disable-line force-element-nesting class-name-format
-      padding-right: 8px;
+  &__btn--trans {
+    border: 0;
+    outline: none;
+    background: transparent;
+    box-shadow: none;
+
+    &:hover,
+    &:active {
+      color: $color-pf-blue-300;
+    }
+
+    &:hover,
+    &:active,
+    &:disabled {
+      background: transparent !important; // sass-lint:disable-line no-important
     }
   }
 
-  &__icon-btn-right {
-    span .fa { // sass-lint:disable-line force-element-nesting class-name-format
-      padding-left: 8px;
-    }
+  &__btn-icon--svg {
+    padding-right: 8px;
+  }
+
+  &__btn-icon--svg-right {
+    padding-left: 8px;
   }
 
   &__bottom-options {
@@ -51,13 +53,13 @@
     .pull-right .btn:not(.dropdown-toggle) { // sass-lint:disable-line force-element-nesting class-name-format
       margin-left: 20px;
     }
+  }
 
-    .tbar { // sass-lint:disable-line force-element-nesting class-name-format
-      margin: 0 20px;
-      padding: 8px 14px;
-      background-color: $color-pf-white;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, .25);
-    }
+  &__bottom-options--tbar {
+    margin: 0 20px;
+    padding: 8px 14px;
+    background-color: $color-pf-white;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, .25);
   }
 
   .PageStatusIcon {

--- a/src/ui/pages/config/PageConfigPage.js
+++ b/src/ui/pages/config/PageConfigPage.js
@@ -159,47 +159,80 @@ class PageConfigPage extends Component {
                   </Col>
                 </Row>
 
-                <Row className="PageConfigPage__toolbar-row PageConfigPage__trans-btns">
+                <Row className="PageConfigPage__toolbar-row PageConfigPage__btn-group--trans">
                   <Col xs={12}>
                     <ButtonToolbar className="pull-left">
                       <Button
-                        className="PageConfigPage__info-btn PageConfigPage__icon-btn"
+                        className={[
+                          'PageConfigPage__info-btn',
+                          'PageConfigPage__btn-icon',
+                          'PageConfigPage__btn--trans',
+                        ].join(' ')}
                         bsStyle="default"
                         onClick={this.toggleInfoTable}
                       >
-                        <span><Icon name={this.state.infoTableOpen ? 'angle-down' : 'angle-right'} /><FormattedMessage id="app.info" /></span>
+                        <span>
+                          <Icon
+                            name={this.state.infoTableOpen ? 'angle-down' : 'angle-right'}
+                            className="PageConfigPage__btn-icon--svg"
+                          />
+                          <FormattedMessage id="app.info" />
+                        </span>
                       </Button>
                     </ButtonToolbar>
-                    <ButtonToolbar className="pull-right further">
+                    <ButtonToolbar className="pull-right">
                       <a
                         href={previewUri}
                         title={formattedText('app.preview', 'Preview')}
-                        className="btn btn-default"
+                        className={[
+                          'btn',
+                          'btn-default',
+                          'PageConfigPage__btn--trans',
+                          'PageConfigPage__btn--addml',
+                        ].join(' ')}
                         target="_blank"
                         rel="noopener noreferrer"
                       >
                         <FormattedMessage id="app.preview" />
                       </a>
                       <Button
-                        className="PageConfigPage__icon-btn-right"
+                        className={[
+                          'PageConfigPage__btn-icon--right',
+                          'PageConfigPage__btn--trans',
+                        ].join(' ')}
                         bsStyle="warning"
                         onClick={restoreConfig}
                         disabled={!pageDiffersFromPublished}
                       >
-                        <span><FormattedMessage id="app.restore" /><Icon name="undo" /></span>
+                        <span>
+                          <FormattedMessage id="app.restore" />
+                          <Icon
+                            name="undo"
+                            className="PageConfigPage__btn-icon--svg-right"
+                          />
+                        </span>
                       </Button>
                       <Button
-                        className="PageConfigPage__icon-btn-right"
+                        className={[
+                          'PageConfigPage__btn-icon--right',
+                          'PageConfigPage__btn--trans',
+                        ].join(' ')}
                         bsStyle="default"
                         onClick={showPageSettings}
                       >
-                        <span><FormattedMessage id="pageSettings.title" /><Icon name="cogs" /></span>
+                        <span>
+                          <FormattedMessage id="pageSettings.title" />
+                          <Icon
+                            name="cogs"
+                            className="PageConfigPage__btn-icon--svg-right"
+                          />
+                        </span>
                       </Button>
                     </ButtonToolbar>
                   </Col>
                 </Row>
                 <Row className="PageConfigPage__toolbar-row PageConfigPage__bottom-options">
-                  <Col xs={8} lg={9} className="tbar">
+                  <Col xs={8} lg={9} className="PageConfigPage__bottom-options--tbar">
                     <ButtonToolbar className="pull-left">
                       { defaultConfigBtn }
                     </ButtonToolbar>

--- a/src/ui/pages/config/PageConfigPage.js
+++ b/src/ui/pages/config/PageConfigPage.js
@@ -159,62 +159,47 @@ class PageConfigPage extends Component {
                   </Col>
                 </Row>
 
-                <Row className="PageConfigPage__toolbar-row">
+                <Row className="PageConfigPage__toolbar-row PageConfigPage__trans-btns">
                   <Col xs={12}>
                     <ButtonToolbar className="pull-left">
                       <Button
-                        className="PageConfigPage__info-btn"
+                        className="PageConfigPage__info-btn PageConfigPage__icon-btn"
                         bsStyle="default"
                         onClick={this.toggleInfoTable}
                       >
-                        <FormattedMessage id="app.info" />
+                        <span><Icon name={this.state.infoTableOpen ? 'angle-down' : 'angle-right'} /><FormattedMessage id="app.info" /></span>
                       </Button>
+                    </ButtonToolbar>
+                    <ButtonToolbar className="pull-right further">
                       <a
                         href={previewUri}
                         title={formattedText('app.preview', 'Preview')}
-                        className="btn btn-primary"
+                        className="btn btn-default"
                         target="_blank"
                         rel="noopener noreferrer"
                       >
                         <FormattedMessage id="app.preview" />
                       </a>
-                    </ButtonToolbar>
-                    <ButtonToolbar className="pull-right">
                       <Button
-                        className="PageConfigPage__settings-btn"
+                        className="PageConfigPage__icon-btn-right"
+                        bsStyle="warning"
+                        onClick={restoreConfig}
+                        disabled={!pageDiffersFromPublished}
+                      >
+                        <span><FormattedMessage id="app.restore" /><Icon name="undo" /></span>
+                      </Button>
+                      <Button
+                        className="PageConfigPage__icon-btn-right"
                         bsStyle="default"
                         onClick={showPageSettings}
                       >
                         <span><FormattedMessage id="pageSettings.title" /><Icon name="cogs" /></span>
                       </Button>
-                      <Button
-                        bsStyle="warning"
-                        onClick={restoreConfig}
-                        disabled={!pageDiffersFromPublished}
-                      >
-                        <FormattedMessage id="app.restore" />
-                      </Button>
-                      <Button
-                        className="PageConfigPage__unpublish-btn"
-                        bsStyle="default"
-                        onClick={unpublishPage}
-                        disabled={!pageIsPublished}
-                      >
-                        <FormattedMessage id="app.unpublish" />
-                      </Button>
-                      <Button
-                        className="PageConfigPage__publish-btn"
-                        bsStyle="success"
-                        onClick={publishPage}
-                        disabled={pageIsPublished}
-                      >
-                        <FormattedMessage id="app.publish" />
-                      </Button>
                     </ButtonToolbar>
                   </Col>
                 </Row>
-                <Row className="PageConfigPage__toolbar-row">
-                  <Col xs={12}>
+                <Row className="PageConfigPage__toolbar-row PageConfigPage__bottom-options">
+                  <Col xs={8} lg={9} className="tbar">
                     <ButtonToolbar className="pull-left">
                       { defaultConfigBtn }
                     </ButtonToolbar>
@@ -244,6 +229,22 @@ class PageConfigPage extends Component {
                           {TRANSLATED_NO}
                         </MenuItem>
                       </DropdownButton>
+                      <Button
+                        className="PageConfigPage__unpublish-btn"
+                        bsStyle="default"
+                        onClick={unpublishPage}
+                        disabled={!pageIsPublished}
+                      >
+                        <FormattedMessage id="app.unpublish" />
+                      </Button>
+                      <Button
+                        className="PageConfigPage__publish-btn btn-primary"
+                        bsStyle="success"
+                        onClick={publishPage}
+                        disabled={pageIsPublished}
+                      >
+                        <FormattedMessage id="app.publish" />
+                      </Button>
                     </div>
                   </Col>
                 </Row>


### PR DESCRIPTION
all the top toolbar buttons are now transparent based on figma. bottom buttons are now in a sticky toolbar right at the bottom.