### PR TITLE
EN-2309 - page config toolbar scroll fix when it is in sticky mode

### DIFF
--- a/sass/pages/config/PageConfigPage.scss
+++ b/sass/pages/config/PageConfigPage.scss
@@ -96,5 +96,6 @@
     position: fixed;
     top: 0;
     right: 0;
+    z-index: 1;
   }
 }


### PR DESCRIPTION
Sorry on finding this late. I found a bug when toolbar is in fixed/sticky mode, toolbar scrolling does not work. This was overlapped with another 'dummy' element thus making scroll wheel not working.