### PR TITLE
get dataTypes mock: mock payload instead of full response

### DIFF
--- a/src/api/dataTypes.js
+++ b/src/api/dataTypes.js
@@ -49,7 +49,7 @@ export const getDataTypes = (page = { page: 1, pageSize: 10 }, params = '') => (
     {
       uri: `/api/dataTypes${params}`,
       method: METHODS.GET,
-      mockResponse: DATA_TYPES_OK_PAGE_1,
+      mockResponse: DATA_TYPES_OK_PAGE_1.payload,
       useAuthentication: true,
     },
     page,

--- a/test/api/dataTypes.test.js
+++ b/test/api/dataTypes.test.js
@@ -36,7 +36,7 @@ import {
 const correctRequest = {
   uri: '/api/dataTypes',
   method: METHODS.GET,
-  mockResponse: DATA_TYPES_OK_PAGE_1,
+  mockResponse: DATA_TYPES_OK_PAGE_1.payload,
   useAuthentication: true,
 };
 


### PR DESCRIPTION
When running app-builder with mocked data, dataTypes fail to get loaded due to the mismatch of response shape in the mock.