### PR TITLE
EN6-72 rebased Docker image to use standard Openshift Nginx image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM nginx:latest
+FROM centos/nginx-112-centos7:latest
 
-EXPOSE 80
+EXPOSE 8081
 ENV HOME=/usr/share/nginx/html/entando
 
 COPY build $HOME/app-builder
-COPY nginx.conf /etc/nginx/nginx.conf
+RUN fix-permissions $HOME
+COPY nginx.conf ${NGINX_CONF_PATH}
+CMD ${STI_SCRIPTS_PATH}/run

--- a/kubernetes.sh
+++ b/kubernetes.sh
@@ -6,4 +6,4 @@ export DIGITAL_EXCHANGE_UI_ENABLED=true
 export ENABLE_DIGITAL_EXCHANGE_UI=true
 export KEYCLOAK_ENABLED=true
 npm run build --production
-docker build -t entando/entando-app-builder:5.2.0-SNAPSHOT .
+docker build -t entando/entando-app-builder-de:6.0.0-SNAPSHOT .

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,7 @@ http {
         root /usr/share/nginx/html/entando;
         index index.html;
         server_name _;
-        listen 80;
+        listen 8081;
 
         location /app-builder/ {
 			try_files $uri $uri/ /app-builder/index.html;


### PR DESCRIPTION
These changes are required for SME to allow the AppBuilder image to be deplyable to Openshift. The previous version of the AppBuilder image was incompatible with Openshift due to a requirement to run as root, which Openshift disallows for security reason. 