### PR TITLE
EN6-92 Fix menu height issue

### DIFF
--- a/sass/internal-page/InternalPage.scss
+++ b/sass/internal-page/InternalPage.scss
@@ -24,6 +24,14 @@
   }
 }
 
+.BrandMenu__first-level-menu {
+  &.nav.persistent-secondary {
+    .LinkMenuItem.active {
+      margin-bottom: 0;
+    }
+  }
+}
+
 .FirstLevelMenuItem {
   span .fa { // sass-lint:disable-line force-element-nesting class-name-format
     padding-right: 8px;

--- a/sass/internal-page/InternalPage.scss
+++ b/sass/internal-page/InternalPage.scss
@@ -24,6 +24,7 @@
   }
 }
 
+// sass-lint:disable force-element-nesting class-name-format nesting-depth
 .BrandMenu__first-level-menu {
   &.nav.persistent-secondary {
     .LinkMenuItem.active {
@@ -31,6 +32,7 @@
     }
   }
 }
+// sass-lint:enable force-element-nesting class-name-format nesting-depth
 
 .FirstLevelMenuItem {
   span .fa { // sass-lint:disable-line force-element-nesting class-name-format


### PR DESCRIPTION
The fix is just by overriding the Patternfly style for active menu items in a persistent secondary navbar. It seems that they didn't consider a mix of multi-level menu items and single-level ones as the corresponding style appears to be only suitable for multi-level items.