### PR TITLE
EN6-147 my profile page fix

### DIFF
--- a/src/ui/users/my-profile/PasswordFormContainer.js
+++ b/src/ui/users/my-profile/PasswordFormContainer.js
@@ -21,6 +21,4 @@ export const mapDispatchToProps = dispatch => ({
 });
 
 
-export default connect(mapStateToProps, mapDispatchToProps, null, {
-  pure: false,
-})(PasswordForm);
+export default connect(mapStateToProps, mapDispatchToProps)(PasswordForm);


### PR DESCRIPTION
It was the 'pure' option in redux connect function that causes the page to go haywire - infinite loops of checks of state values most especially the `matchElement` validation that is found on `newPasswordConfirm`. If there's a matchElement validation, better avoid turning on `pure` option.