### PR TITLE
EN6-172 dispatch prop onWillMount not found error fix

### DIFF
--- a/src/ui/users/list/UserSearchFormContainer.js
+++ b/src/ui/users/list/UserSearchFormContainer.js
@@ -43,5 +43,7 @@ export const mapDispatchToProps = dispatch => ({
 const UserSearchFormContainer = connect(
   mapStateToProps,
   mapDispatchToProps,
+  null,
+  { pure: false },
 )(UserSearchForm);
 export default UserSearchFormContainer;


### PR DESCRIPTION
prop 'onWillMount' attempts to invoke but not found on user list. this only happens when it is integrated with entando app such as CMS