### PR TITLE
ENG-7 Activate a spinner while in loading state

### DIFF
--- a/src/state/digital-exchange/components/actions.js
+++ b/src/state/digital-exchange/components/actions.js
@@ -272,7 +272,7 @@ export const fetchDEComponents = (paginationMetadata = {
         dispatch(toggleLoading(feature));
         resolve();
       });
-    }).catch(() => {});
+    }).catch(() => { dispatch(toggleLoading(feature)); });
   })
 );
 

--- a/src/ui/digital-exchange/components/list/ComponentListContainer.js
+++ b/src/ui/digital-exchange/components/list/ComponentListContainer.js
@@ -5,11 +5,13 @@ import { getDEComponentList, getDEComponentListViewMode } from 'state/digital-ex
 import { getLoading } from 'state/loading/selectors';
 import ComponentList from 'ui/digital-exchange/components/list/ComponentList';
 
+const deLoading = 'digital-exchange/components';
+
 export const mapStateToProps = state => (
   {
     digitalExchangeComponents: getDEComponentList(state),
     viewMode: getDEComponentListViewMode(state),
-    loading: getLoading(state).digitalExchangeComponents,
+    loading: getLoading(state)[deLoading],
   }
 );
 

--- a/src/ui/pages/config/PageConfigPage.js
+++ b/src/ui/pages/config/PageConfigPage.js
@@ -60,9 +60,6 @@ class PageConfigPage extends Component {
 
   componentDidMount() {
     window.addEventListener('scroll', this.winScrollListener);
-
-    // hide body's scroll bar to prevent conflict with sidebar's scroll bar
-    document.body.classList.add('no-scroll');
   }
 
   componentWillReceiveProps(nextProps) {
@@ -84,7 +81,6 @@ class PageConfigPage extends Component {
   componentWillUnmount() {
     if (this.props.onWillUnmount) this.props.onWillUnmount(this.props);
     window.removeEventListener('scroll', this.winScrollListener);
-    document.body.classList.remove('no-scroll');
   }
 
   removeStatusAlert() {


### PR DESCRIPTION
This commit includes spinner activation and no-scroll issue resolve.
1. Spinner activation was accessing the spinner status incorrectly from the state. Also, toggleLoading was never called when there are no Digital Exchanges available, as API is returning 304 code without any JSON, so frontend fetching PROMISE outputs error (no JSON returned) instead of resolving. That's why I put toggleLoading in error too.
2. I tested while no-scroll removed and all worked like a charm and smoothly. So, I think this way is better.