### PR TITLE
ENG-29 DE Component Install/Uninstall Button Feedback

### DIFF
--- a/src/state/digital-exchange/components/actions.js
+++ b/src/state/digital-exchange/components/actions.js
@@ -175,7 +175,7 @@ export const pollDEComponentInstallStatus = component => dispatch => (
 
 export const installDEComponent = component => dispatch => (
   new Promise((resolve) => {
-    const loadingId = `deComponentInstallStart-${component.id}`;
+    const loadingId = `deComponentInstallUninstall-${component.id}`;
     dispatch(toggleLoading(loadingId));
     postDEComponentInstall(component).then((response) => {
       response.json().then((data) => {
@@ -243,7 +243,7 @@ export const pollDEComponentUninstallStatus = componentId => dispatch => (
 
 export const uninstallDEComponent = componentId => dispatch => (
   new Promise((resolve) => {
-    const loadingId = `deComponentUninstallStart-${componentId}`;
+    const loadingId = `deComponentInstallUninstall-${componentId}`;
     dispatch(toggleLoading(loadingId));
     postDEComponentUninstall(componentId).then((response) => {
       response.json().then((data) => {

--- a/src/state/digital-exchange/components/actions.js
+++ b/src/state/digital-exchange/components/actions.js
@@ -243,6 +243,8 @@ export const pollDEComponentUninstallStatus = componentId => dispatch => (
 
 export const uninstallDEComponent = componentId => dispatch => (
   new Promise((resolve) => {
+    const loadingId = `deComponentUninstallStart-${componentId}`;
+    dispatch(toggleLoading(loadingId));
     postDEComponentUninstall(componentId).then((response) => {
       response.json().then((data) => {
         if (response.ok) {
@@ -252,6 +254,7 @@ export const uninstallDEComponent = componentId => dispatch => (
           dispatch(addErrors(data.errors.map(err => err.message)));
           resolve();
         }
+        dispatch(toggleLoading(loadingId));
       });
     }).catch(() => {});
   })

--- a/src/state/digital-exchange/components/actions.js
+++ b/src/state/digital-exchange/components/actions.js
@@ -175,6 +175,8 @@ export const pollDEComponentInstallStatus = component => dispatch => (
 
 export const installDEComponent = component => dispatch => (
   new Promise((resolve) => {
+    const loadingId = `deComponentInstallStart-${component.id}`;
+    dispatch(toggleLoading(loadingId));
     postDEComponentInstall(component).then((response) => {
       response.json().then((data) => {
         if (response.ok) {
@@ -184,6 +186,7 @@ export const installDEComponent = component => dispatch => (
           dispatch(addErrors(data.errors.map(err => err.message)));
           resolve();
         }
+        dispatch(toggleLoading(loadingId));
       });
     }).catch(() => {});
   })

--- a/src/ui/digital-exchange/components/common/ComponentInstallActions.js
+++ b/src/ui/digital-exchange/components/common/ComponentInstallActions.js
@@ -23,6 +23,7 @@ const ComponentInstallActions = ({
   installationStatus,
   uninstallStatus,
   installStartLoading,
+  uninstallStartLoading,
   onInstall,
   onUninstall,
   onRecheckStatus,
@@ -62,16 +63,18 @@ const ComponentInstallActions = ({
 
   return (component.installed && uninstallStatus === '') ? (
     <div className="ComponentList__install-actions">
-      <span className="ComponentList__status">
-        <FormattedMessage id="digitalExchange.components.installed" />
-      </span>
-      <Button
-        bsStyle="link"
-        className="ComponentList__uninstall"
-        onClick={() => onUninstall(component.id)}
-      >
-        <FormattedMessage id="digitalExchange.components.uninstall" />
-      </Button>
+      <Spinner loading={uninstallStartLoading}>
+        <span className="ComponentList__status">
+          <FormattedMessage id="digitalExchange.components.installed" />
+        </span>
+        <Button
+          bsStyle="link"
+          className="ComponentList__uninstall"
+          onClick={() => onUninstall(component.id)}
+        >
+          <FormattedMessage id="digitalExchange.components.uninstall" />
+        </Button>
+      </Spinner>
     </div>
   ) : (
     <div className="ComponentList__install-actions">
@@ -109,6 +112,7 @@ ComponentInstallActions.propTypes = {
   onRecheckStatus: PropTypes.func.isRequired,
   onRetryAction: PropTypes.func.isRequired,
   installStartLoading: PropTypes.bool.isRequired,
+  uninstallStartLoading: PropTypes.bool.isRequired,
 };
 
 export default ComponentInstallActions;

--- a/src/ui/digital-exchange/components/common/ComponentInstallActions.js
+++ b/src/ui/digital-exchange/components/common/ComponentInstallActions.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, ProgressBar } from 'patternfly-react';
+import { Button, ProgressBar, Spinner } from 'patternfly-react';
 import { FormattedMessage } from 'react-intl';
 import { componentType } from 'models/digital-exchange/components';
 import {
@@ -22,6 +22,7 @@ const ComponentInstallActions = ({
   lastInstallStatus,
   installationStatus,
   uninstallStatus,
+  installStartLoading,
   onInstall,
   onUninstall,
   onRecheckStatus,
@@ -74,24 +75,26 @@ const ComponentInstallActions = ({
     </div>
   ) : (
     <div className="ComponentList__install-actions">
-      {
-        (jobProgressStatuses.includes(installationStatus) ||
-        jobProgressStatuses.includes(uninstallStatus)) ? (
-          <ProgressBar
-            active
-            bsStyle="success"
-            now={100}
-          />
-        ) : (
-          <Button
-            bsStyle="primary"
-            className="ComponentList__install"
-            onClick={() => onInstall(component)}
-          >
-            <FormattedMessage id="digitalExchange.components.install" />
-          </Button>
-        )
-      }
+      <Spinner loading={installStartLoading}>
+        {
+          (jobProgressStatuses.includes(installationStatus) ||
+          jobProgressStatuses.includes(uninstallStatus)) ? (
+            <ProgressBar
+              active
+              bsStyle="success"
+              now={100}
+            />
+          ) : (
+            <Button
+              bsStyle="primary"
+              className="ComponentList__install"
+              onClick={() => onInstall(component)}
+            >
+              <FormattedMessage id="digitalExchange.components.install" />
+            </Button>
+          )
+        }
+      </Spinner>
     </div>
   );
 };
@@ -105,6 +108,7 @@ ComponentInstallActions.propTypes = {
   uninstallStatus: PropTypes.string.isRequired,
   onRecheckStatus: PropTypes.func.isRequired,
   onRetryAction: PropTypes.func.isRequired,
+  installStartLoading: PropTypes.bool.isRequired,
 };
 
 export default ComponentInstallActions;

--- a/src/ui/digital-exchange/components/common/ComponentInstallActions.js
+++ b/src/ui/digital-exchange/components/common/ComponentInstallActions.js
@@ -22,8 +22,7 @@ const ComponentInstallActions = ({
   lastInstallStatus,
   installationStatus,
   uninstallStatus,
-  installStartLoading,
-  uninstallStartLoading,
+  installUninstallLoading,
   onInstall,
   onUninstall,
   onRecheckStatus,
@@ -63,7 +62,7 @@ const ComponentInstallActions = ({
 
   return (component.installed && uninstallStatus === '') ? (
     <div className="ComponentList__install-actions">
-      <Spinner loading={uninstallStartLoading}>
+      <Spinner loading={installUninstallLoading}>
         <span className="ComponentList__status">
           <FormattedMessage id="digitalExchange.components.installed" />
         </span>
@@ -78,7 +77,7 @@ const ComponentInstallActions = ({
     </div>
   ) : (
     <div className="ComponentList__install-actions">
-      <Spinner loading={installStartLoading}>
+      <Spinner loading={installUninstallLoading}>
         {
           (jobProgressStatuses.includes(installationStatus) ||
           jobProgressStatuses.includes(uninstallStatus)) ? (
@@ -111,8 +110,7 @@ ComponentInstallActions.propTypes = {
   uninstallStatus: PropTypes.string.isRequired,
   onRecheckStatus: PropTypes.func.isRequired,
   onRetryAction: PropTypes.func.isRequired,
-  installStartLoading: PropTypes.bool.isRequired,
-  uninstallStartLoading: PropTypes.bool.isRequired,
+  installUninstallLoading: PropTypes.bool.isRequired,
 };
 
 export default ComponentInstallActions;

--- a/src/ui/digital-exchange/components/common/ComponentInstallActions.js
+++ b/src/ui/digital-exchange/components/common/ComponentInstallActions.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Button, ProgressBar, Spinner } from 'patternfly-react';
 import { FormattedMessage } from 'react-intl';
@@ -60,42 +60,48 @@ const ComponentInstallActions = ({
     );
   }
 
-  return (component.installed && uninstallStatus === '') ? (
-    <div className="ComponentList__install-actions">
-      <Spinner loading={installUninstallLoading}>
-        <span className="ComponentList__status">
-          <FormattedMessage id="digitalExchange.components.installed" />
-        </span>
+  const renderedUninstallButton = (
+    <Fragment>
+      <span className="ComponentList__status">
+        <FormattedMessage id="digitalExchange.components.installed" />
+      </span>
+      <Button
+        bsStyle="link"
+        className="ComponentList__uninstall"
+        onClick={() => onUninstall(component.id)}
+      >
+        <FormattedMessage id="digitalExchange.components.uninstall" />
+      </Button>
+    </Fragment>
+  );
+
+  const renderedInstallButton = (
+    jobProgressStatuses.includes(installationStatus) ||
+    jobProgressStatuses.includes(uninstallStatus) ? (
+      <ProgressBar
+        active
+        bsStyle="success"
+        now={100}
+      />
+      ) : (
         <Button
-          bsStyle="link"
-          className="ComponentList__uninstall"
-          onClick={() => onUninstall(component.id)}
+          bsStyle="primary"
+          className="ComponentList__install"
+          onClick={() => onInstall(component)}
         >
-          <FormattedMessage id="digitalExchange.components.uninstall" />
+          <FormattedMessage id="digitalExchange.components.install" />
         </Button>
-      </Spinner>
-    </div>
-  ) : (
+      )
+  );
+
+  const renderedButton = (component.installed && uninstallStatus === '')
+    ? renderedUninstallButton
+    : renderedInstallButton;
+
+  return (
     <div className="ComponentList__install-actions">
       <Spinner loading={installUninstallLoading}>
-        {
-          (jobProgressStatuses.includes(installationStatus) ||
-          jobProgressStatuses.includes(uninstallStatus)) ? (
-            <ProgressBar
-              active
-              bsStyle="success"
-              now={100}
-            />
-          ) : (
-            <Button
-              bsStyle="primary"
-              className="ComponentList__install"
-              onClick={() => onInstall(component)}
-            >
-              <FormattedMessage id="digitalExchange.components.install" />
-            </Button>
-          )
-        }
+        {renderedButton}
       </Spinner>
     </div>
   );

--- a/src/ui/digital-exchange/components/common/ComponentInstallActionsContainer.js
+++ b/src/ui/digital-exchange/components/common/ComponentInstallActionsContainer.js
@@ -11,11 +11,13 @@ import {
   getDEComponentInstallationStatus,
   getDEComponentUninstallStatus,
 } from 'state/digital-exchange/components/selectors';
+import { getLoading } from 'state/loading/selectors';
 
 export const mapStateToProps = (state, props) => ({
   lastInstallStatus: getDEComponentLastInstallStatus(state, props),
   installationStatus: getDEComponentInstallationStatus(state, props),
   uninstallStatus: getDEComponentUninstallStatus(state, props),
+  installStartLoading: !!getLoading(state)[`deComponentInstallStart-${props.component.id}`],
 });
 
 export const mapDispatchToProps = dispatch => ({

--- a/src/ui/digital-exchange/components/common/ComponentInstallActionsContainer.js
+++ b/src/ui/digital-exchange/components/common/ComponentInstallActionsContainer.js
@@ -17,8 +17,7 @@ export const mapStateToProps = (state, props) => ({
   lastInstallStatus: getDEComponentLastInstallStatus(state, props),
   installationStatus: getDEComponentInstallationStatus(state, props),
   uninstallStatus: getDEComponentUninstallStatus(state, props),
-  installStartLoading: !!getLoading(state)[`deComponentInstallStart-${props.component.id}`],
-  uninstallStartLoading: !!getLoading(state)[`deComponentUninstallStart-${props.component.id}`],
+  installUninstallLoading: !!getLoading(state)[`deComponentInstallUninstall-${props.component.id}`],
 });
 
 export const mapDispatchToProps = dispatch => ({

--- a/src/ui/digital-exchange/components/common/ComponentInstallActionsContainer.js
+++ b/src/ui/digital-exchange/components/common/ComponentInstallActionsContainer.js
@@ -18,6 +18,7 @@ export const mapStateToProps = (state, props) => ({
   installationStatus: getDEComponentInstallationStatus(state, props),
   uninstallStatus: getDEComponentUninstallStatus(state, props),
   installStartLoading: !!getLoading(state)[`deComponentInstallStart-${props.component.id}`],
+  uninstallStartLoading: !!getLoading(state)[`deComponentUninstallStart-${props.component.id}`],
 });
 
 export const mapDispatchToProps = dispatch => ({

--- a/test/state/digital-exchange/components/actions.test.js
+++ b/test/state/digital-exchange/components/actions.test.js
@@ -124,9 +124,11 @@ describe('state/digital-exchange/components/actions', () => {
 
       store.dispatch(installDEComponent(GET_DE_COMPONENT_OK)).then(() => {
         const actions = store.getActions();
-        expect(actions).toHaveLength(2);
-        expect(actions[0]).toHaveProperty('type', START_COMPONENT_INSTALLATION);
-        expect(actions[1]).toHaveProperty('type', FINISH_COMPONENT_INSTALLATION);
+        expect(actions).toHaveLength(4);
+        expect(actions[0]).toHaveProperty('type', TOGGLE_LOADING);
+        expect(actions[1]).toHaveProperty('type', START_COMPONENT_INSTALLATION);
+        expect(actions[2]).toHaveProperty('type', TOGGLE_LOADING);
+        expect(actions[3]).toHaveProperty('type', FINISH_COMPONENT_INSTALLATION);
         done();
       }).catch(done.fail);
     });
@@ -138,11 +140,13 @@ describe('state/digital-exchange/components/actions', () => {
 
       store.dispatch(installDEComponent(GET_DE_COMPONENT_OK)).then(() => {
         const actions = store.getActions();
-        expect(actions).toHaveLength(4);
-        expect(actions[0]).toHaveProperty('type', START_COMPONENT_INSTALLATION);
-        expect(actions[1]).toHaveProperty('type', ADD_TOAST);
-        expect(actions[2]).toHaveProperty('type', COMPONENT_INSTALLATION_FAILED);
-        expect(actions[3]).toHaveProperty('type', ADD_ERRORS);
+        expect(actions).toHaveLength(6);
+        expect(actions[0]).toHaveProperty('type', TOGGLE_LOADING);
+        expect(actions[1]).toHaveProperty('type', START_COMPONENT_INSTALLATION);
+        expect(actions[2]).toHaveProperty('type', TOGGLE_LOADING);
+        expect(actions[3]).toHaveProperty('type', ADD_TOAST);
+        expect(actions[4]).toHaveProperty('type', COMPONENT_INSTALLATION_FAILED);
+        expect(actions[5]).toHaveProperty('type', ADD_ERRORS);
         done();
       }).catch(done.fail);
     });
@@ -151,8 +155,10 @@ describe('state/digital-exchange/components/actions', () => {
       postDEComponentInstall.mockImplementation(mockApi({ errors: true }));
       store.dispatch(installDEComponent(GET_DE_COMPONENT_OK)).then(() => {
         const actions = store.getActions();
-        expect(actions).toHaveLength(1);
-        expect(actions[0]).toHaveProperty('type', ADD_ERRORS);
+        expect(actions).toHaveLength(3);
+        expect(actions[0]).toHaveProperty('type', TOGGLE_LOADING);
+        expect(actions[1]).toHaveProperty('type', ADD_ERRORS);
+        expect(actions[2]).toHaveProperty('type', TOGGLE_LOADING);
         done();
       }).catch(done.fail);
     });

--- a/test/state/digital-exchange/components/actions.test.js
+++ b/test/state/digital-exchange/components/actions.test.js
@@ -178,9 +178,11 @@ describe('state/digital-exchange/components/actions', () => {
 
       store.dispatch(uninstallDEComponent(GET_DE_COMPONENT_OK.id)).then(() => {
         const actions = store.getActions();
-        expect(actions).toHaveLength(2);
-        expect(actions[0]).toHaveProperty('type', START_COMPONENT_UNINSTALLATION);
-        expect(actions[1]).toHaveProperty('type', FINISH_COMPONENT_UNINSTALLATION);
+        expect(actions).toHaveLength(4);
+        expect(actions[0]).toHaveProperty('type', TOGGLE_LOADING);
+        expect(actions[1]).toHaveProperty('type', START_COMPONENT_UNINSTALLATION);
+        expect(actions[2]).toHaveProperty('type', TOGGLE_LOADING);
+        expect(actions[3]).toHaveProperty('type', FINISH_COMPONENT_UNINSTALLATION);
         done();
       }).catch(done.fail);
     });
@@ -192,11 +194,13 @@ describe('state/digital-exchange/components/actions', () => {
 
       store.dispatch(uninstallDEComponent(GET_DE_COMPONENT_OK.id)).then(() => {
         const actions = store.getActions();
-        expect(actions).toHaveLength(4);
-        expect(actions[0]).toHaveProperty('type', START_COMPONENT_UNINSTALLATION);
-        expect(actions[1]).toHaveProperty('type', ADD_TOAST);
-        expect(actions[2]).toHaveProperty('type', COMPONENT_UNINSTALLATION_FAILED);
-        expect(actions[3]).toHaveProperty('type', ADD_ERRORS);
+        expect(actions).toHaveLength(6);
+        expect(actions[0]).toHaveProperty('type', TOGGLE_LOADING);
+        expect(actions[1]).toHaveProperty('type', START_COMPONENT_UNINSTALLATION);
+        expect(actions[2]).toHaveProperty('type', TOGGLE_LOADING);
+        expect(actions[3]).toHaveProperty('type', ADD_TOAST);
+        expect(actions[4]).toHaveProperty('type', COMPONENT_UNINSTALLATION_FAILED);
+        expect(actions[5]).toHaveProperty('type', ADD_ERRORS);
         done();
       }).catch(done.fail);
     });
@@ -205,8 +209,10 @@ describe('state/digital-exchange/components/actions', () => {
       postDEComponentUninstall.mockImplementation(mockApi({ errors: true }));
       store.dispatch(uninstallDEComponent(GET_DE_COMPONENT_OK.id)).then(() => {
         const actions = store.getActions();
-        expect(actions).toHaveLength(1);
-        expect(actions[0]).toHaveProperty('type', ADD_ERRORS);
+        expect(actions).toHaveLength(3);
+        expect(actions[0]).toHaveProperty('type', TOGGLE_LOADING);
+        expect(actions[1]).toHaveProperty('type', ADD_ERRORS);
+        expect(actions[2]).toHaveProperty('type', TOGGLE_LOADING);
         done();
       }).catch(done.fail);
     });

--- a/test/ui/digital-exchange/components/common/ComponentInstallActionsContainer.test.js
+++ b/test/ui/digital-exchange/components/common/ComponentInstallActionsContainer.test.js
@@ -23,8 +23,7 @@ const MOCK_STATE = {
     uninstallation,
   },
   loading: {
-    [`deComponentInstallStart-${COMPONENT_INSTALLATION_IN_PROGRESS.componentId}`]: false,
-    [`deComponentUninstallStart-${COMPONENT_INSTALLATION_IN_PROGRESS.componentId}`]: false,
+    [`deComponentInstallUninstall-${COMPONENT_INSTALLATION_IN_PROGRESS.componentId}`]: false,
   },
 };
 
@@ -40,8 +39,7 @@ describe('ComponentInstallActionsContainer', () => {
       lastInstallStatus: getDEComponentLastInstallStatus(MOCK_STATE, MOCK_PROPS),
       installationStatus: getDEComponentInstallationStatus(MOCK_STATE, MOCK_PROPS),
       uninstallStatus: getDEComponentUninstallStatus(MOCK_STATE, MOCK_PROPS),
-      installStartLoading: false,
-      uninstallStartLoading: false,
+      installUninstallLoading: false,
     });
   });
 

--- a/test/ui/digital-exchange/components/common/ComponentInstallActionsContainer.test.js
+++ b/test/ui/digital-exchange/components/common/ComponentInstallActionsContainer.test.js
@@ -22,6 +22,9 @@ const MOCK_STATE = {
     installation,
     uninstallation,
   },
+  loading: {
+    [`deComponentInstallStart-${COMPONENT_INSTALLATION_IN_PROGRESS.componentId}`]: false,
+  },
 };
 
 const MOCK_PROPS = {
@@ -36,6 +39,7 @@ describe('ComponentInstallActionsContainer', () => {
       lastInstallStatus: getDEComponentLastInstallStatus(MOCK_STATE, MOCK_PROPS),
       installationStatus: getDEComponentInstallationStatus(MOCK_STATE, MOCK_PROPS),
       uninstallStatus: getDEComponentUninstallStatus(MOCK_STATE, MOCK_PROPS),
+      installStartLoading: false,
     });
   });
 

--- a/test/ui/digital-exchange/components/common/ComponentInstallActionsContainer.test.js
+++ b/test/ui/digital-exchange/components/common/ComponentInstallActionsContainer.test.js
@@ -24,6 +24,7 @@ const MOCK_STATE = {
   },
   loading: {
     [`deComponentInstallStart-${COMPONENT_INSTALLATION_IN_PROGRESS.componentId}`]: false,
+    [`deComponentUninstallStart-${COMPONENT_INSTALLATION_IN_PROGRESS.componentId}`]: false,
   },
 };
 
@@ -40,6 +41,7 @@ describe('ComponentInstallActionsContainer', () => {
       installationStatus: getDEComponentInstallationStatus(MOCK_STATE, MOCK_PROPS),
       uninstallStatus: getDEComponentUninstallStatus(MOCK_STATE, MOCK_PROPS),
       installStartLoading: false,
+      uninstallStartLoading: false,
     });
   });
 


### PR DESCRIPTION
After clicking an install or uninstall button, a spinner will instantaneously be shown to provide immediate feedback to the user prior to the actual start of the installation/uninstallation of a DE component.