### PR TITLE
ENG-36 catch unathorized error

### DIFF
--- a/src/state/login-form/actions.js
+++ b/src/state/login-form/actions.js
@@ -35,7 +35,10 @@ export const performLogin = (username, password) => dispatch => (
           dispatch(setLoginErrorMessage(formattedText('fcc.login.errorMessage', ERROR_LOGIN_MESSAGE, {})));
           resolve();
         }
-      }).catch(() => {});
+      }).catch(() => {
+        dispatch(setLoginErrorMessage(formattedText('fcc.login.errorMessage', ERROR_LOGIN_MESSAGE, {})));
+        resolve();
+      });
     } else {
       dispatch(setLoginErrorMessage(formattedText('fcc.login.errorMessage', ERROR_LOGIN_MESSAGE, {})));
       resolve();


### PR DESCRIPTION
`login` function responds with 401 unauthorized error from API, which does not go to `then` but to `catch`, where we did not have any logic to handle it, due to it UX was not indicating any error and the user thought he was stuck on the page and screen was `frozen`.