### PR TITLE
EN-59 other i18n fixes

### DIFF
--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -385,7 +385,7 @@ export default {
     'fragment.table.edit': 'Modifica {code}',
     'fragment.table.details': 'Dettagli di: {code}',
     'fragment.form.edit.plugin': 'Plugin',
-    'fragment.form.edit.widgetType': 'Widget Type',
+    'fragment.form.edit.widgetType': 'Tipo di Widget',
     'fragment.settings': 'Abilita la creazione di fragment con default GUI vuota',
     'fragment.settings.alert.success': 'Le impostazioni sono state aggiornate',
     'fragment.settings.alert.error': 'Le impostazioni non sono state aggiornate',


### PR DESCRIPTION
use "tipo di widget" to translate "widget type" as it was already used that way