### PR TITLE
ENG-387 Add ConfirmUninstallModal to ComponentInstallActions

### DIFF
--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -681,6 +681,7 @@ export default {
     'digitalExchange.components.notifyFailedInstall': 'An error has occured during installation.',
     'digitalExchange.components.notifyFailedUninstall': 'An error has occured during uninstallation.',
     'digitalExchange.components.uninstall': 'Uninstall',
+    'digitalExchange.components.confirmUninstall': 'Do you really want to uninstall component {name}?',
     'digitalExchange.sidebar.ratingFilter.title': 'Rating',
     'digitalExchange.sidebar.ratingFilter.itemLabel': '& up',
     'digitalExchange.categories.all': 'All',

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -681,6 +681,7 @@ export default {
     'digitalExchange.components.notifyFailedInstall': 'Si è verificato un errore durante l\'installazione.',
     'digitalExchange.components.notifyFailedUninstall': 'Si è verificato un errore durante la disinstallazione.',
     'digitalExchange.components.uninstall': 'Disinstalla',
+    'digitalExchange.components.confirmUninstall': 'Vuoi veramente disinstallare il componente {name}?',
     'digitalExchange.sidebar.ratingFilter.title': 'Media voto',
     'digitalExchange.sidebar.ratingFilter.itemLabel': 'e più',
     'digitalExchange.categories.all': 'Tutti',

--- a/src/locales/pt.js
+++ b/src/locales/pt.js
@@ -676,6 +676,7 @@ export default {
     'digitalExchange.components.notifyFailedInstall': 'Ocorreu um erro durante a instalação.',
     'digitalExchange.components.notifyFailedUninstall': 'Ocorreu um erro durante a desinstalação.',
     'digitalExchange.components.uninstall': 'Desinstalar',
+    'digitalExchange.components.confirmUninstall': 'Deseja realmente desinstalar o componente {name}?',
     'digitalExchange.sidebar.ratingFilter.title': 'Avaliação',
     'digitalExchange.sidebar.ratingFilter.itemLabel': '& up',
     'digitalExchange.categories.all': 'Todos',

--- a/src/ui/digital-exchange/components/common/ComponentInstallActions.js
+++ b/src/ui/digital-exchange/components/common/ComponentInstallActions.js
@@ -9,6 +9,7 @@ import {
   DE_COMPONENT_UNINSTALLATION_STATUS_CREATED,
   DE_COMPONENT_UNINSTALLATION_STATUS_IN_PROGRESS,
 } from 'state/digital-exchange/components/const';
+import ConfirmUninstallModal from 'ui/digital-exchange/components/common/ConfirmUninstallModal';
 
 const jobProgressStatuses = [
   DE_COMPONENT_INSTALLATION_STATUS_CREATED,
@@ -25,6 +26,7 @@ const ComponentInstallActions = ({
   installUninstallLoading,
   onInstall,
   onUninstall,
+  onClickUninstall,
   onRecheckStatus,
   onRetryAction,
 }) => {
@@ -68,7 +70,7 @@ const ComponentInstallActions = ({
       <Button
         bsStyle="link"
         className="ComponentList__uninstall"
-        onClick={() => onUninstall(component.id)}
+        onClick={() => onClickUninstall(component.id)}
       >
         <FormattedMessage id="digitalExchange.components.uninstall" />
       </Button>
@@ -103,6 +105,10 @@ const ComponentInstallActions = ({
       <Spinner loading={installUninstallLoading}>
         {renderedButton}
       </Spinner>
+      <ConfirmUninstallModal
+        info={{ id: component.id, name: component.name }}
+        onConfirmUninstall={() => onUninstall(component.id)}
+      />
     </div>
   );
 };
@@ -113,6 +119,7 @@ ComponentInstallActions.propTypes = {
   lastInstallStatus: PropTypes.string.isRequired,
   onInstall: PropTypes.func.isRequired,
   onUninstall: PropTypes.func.isRequired,
+  onClickUninstall: PropTypes.func.isRequired,
   uninstallStatus: PropTypes.string.isRequired,
   onRecheckStatus: PropTypes.func.isRequired,
   onRetryAction: PropTypes.func.isRequired,

--- a/src/ui/digital-exchange/components/common/ComponentInstallActionsContainer.js
+++ b/src/ui/digital-exchange/components/common/ComponentInstallActionsContainer.js
@@ -12,6 +12,7 @@ import {
   getDEComponentUninstallStatus,
 } from 'state/digital-exchange/components/selectors';
 import { getLoading } from 'state/loading/selectors';
+import { setVisibleModal } from 'state/modal/actions';
 
 export const mapStateToProps = (state, props) => ({
   lastInstallStatus: getDEComponentLastInstallStatus(state, props),
@@ -22,7 +23,11 @@ export const mapStateToProps = (state, props) => ({
 
 export const mapDispatchToProps = dispatch => ({
   onInstall: component => dispatch(installDEComponent(component)),
-  onUninstall: componentId => dispatch(uninstallDEComponent(componentId)),
+  onUninstall: (componentId) => {
+    dispatch(setVisibleModal(''));
+    return dispatch(uninstallDEComponent(componentId));
+  },
+  onClickUninstall: componentId => dispatch(setVisibleModal(componentId)),
   recheckInstallStatus: component => dispatch(pollDEComponentInstallStatus(component)),
   recheckUninstallStatus: componentId => dispatch(pollDEComponentUninstallStatus(componentId)),
 });

--- a/src/ui/digital-exchange/components/common/ConfirmUninstallModal.js
+++ b/src/ui/digital-exchange/components/common/ConfirmUninstallModal.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import GenericModalContainer from 'ui/common/modal/GenericModalContainer';
+import {
+  Button, EmptyState, Modal,
+  EmptyStateIcon, EmptyStateTitle, EmptyStateInfo,
+} from 'patternfly-react';
+
+const ConfirmUninstallModal = ({
+  onConfirmUninstall, info,
+}) => {
+  const onUninstall = () => {
+    onConfirmUninstall();
+  };
+
+  const buttons = [
+    <Button bsStyle="danger" id="ConfirmUninstallModal_button" onClick={onUninstall}>
+      <FormattedMessage id="digitalExchange.components.uninstall" />
+    </Button>,
+  ];
+
+  const modalTitle = (
+    <Modal.Title><FormattedMessage id="digitalExchange.components.uninstall" /></Modal.Title>
+  );
+
+  return (
+    <GenericModalContainer modalId={info.id} buttons={buttons} modalTitle={modalTitle}>
+      <EmptyState>
+        <EmptyStateIcon name="exclamation" type="fa" />
+        <EmptyStateTitle>
+          <FormattedMessage id="digitalExchange.components.uninstall" />
+        </EmptyStateTitle>
+        <EmptyStateInfo>
+          <FormattedMessage id="digitalExchange.components.confirmUninstall" values={{ name: info.name }} />
+        </EmptyStateInfo>
+      </EmptyState>
+    </GenericModalContainer>
+  );
+};
+
+ConfirmUninstallModal.propTypes = {
+  onConfirmUninstall: PropTypes.func.isRequired,
+  info: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string,
+  }).isRequired,
+};
+
+export default ConfirmUninstallModal;


### PR DESCRIPTION
Implements confirmation modal shown on the uninstall of a digital exchange component.