### PR TITLE
ENG-519 implement app-builder side for expand/collapse all

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -422,20 +422,20 @@
           }
         },
         "react-dom": {
-          "version": "16.12.0",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
-          "integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+          "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
-            "scheduler": "^0.18.0"
+            "scheduler": "^0.19.1"
           }
         },
         "scheduler": {
-          "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
-          "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -392,9 +392,9 @@
       }
     },
     "@entando/pagetreeselector": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@entando/pagetreeselector/-/pagetreeselector-1.1.0.tgz",
-      "integrity": "sha512-GHtOhPqSHa8Cavk6jEUiEVfbQP3yDNPu1XUpFSyqEEn2b1tPtHE+9mca3kbQ7H26WZx8maIMZAa5AGukD5KE4w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@entando/pagetreeselector/-/pagetreeselector-2.0.0.tgz",
+      "integrity": "sha512-RmU70highio+q8rPOdUl1T8E8vST5vYc2EGYd9qYadUV6RJjVx8/gCb0JqWB3RY2R+/hY/ryHSyzSOaRI3kk7A==",
       "requires": {
         "react": "^16.3.0",
         "react-dom": "^16.12.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@entando/menu": "^2.1.0",
     "@entando/messages": "^1.0.4",
     "@entando/pages": "^3.1.3",
-    "@entando/pagetreeselector": "^1.1.0",
+    "@entando/pagetreeselector": "^2.0.0",
     "@entando/utils": "^2.1.1",
     "autoprefixer": "7.1.6",
     "babel-core": "^6.26.3",

--- a/sass/pages/common/PageTree.scss
+++ b/sass/pages/common/PageTree.scss
@@ -42,6 +42,16 @@
     padding: 0 10px;
     outline: 0;
   }
+
+  &__toggler {
+    display: inline-block;
+    margin-right: 30px;
+    cursor: pointer;
+
+    &--expand {
+      margin-left: 4em;
+    }
+  }
 }
 
 

--- a/sass/pages/config/ContentPages.scss
+++ b/sass/pages/config/ContentPages.scss
@@ -13,4 +13,25 @@
     margin-right: 3px;
   }
 
+  &__pagetree-actions {
+    display: flex;
+    align-items: center;
+    height: 40px;
+    padding-left: 10px;
+    background: $color-widget-title-bg-color;
+    color: $color-black;
+  }
+
+  &__toggler {
+    display: inline-block;
+    margin-right: 10px;
+    font-family: "Open Sans";
+    font-size: 13px;
+    line-height: 1.66666667;
+
+    span {
+      margin-right: 5px;
+    }
+  }
+
 }

--- a/src/state/pages/reducer.js
+++ b/src/state/pages/reducer.js
@@ -158,14 +158,12 @@ const titlesMap = (state = {}, action = {}) => {
   }
 };
 
-const toggleBatchExpandedValues = (arr, toggleValue) => {
-  const newState = {};
-  arr.map((pg) => {
-    newState[pg] = { loaded: true, loading: false, expanded: toggleValue };
-    return pg;
-  });
-  return newState;
-};
+const toggleBatchExpandedValues = (arr, toggleValue) => arr.reduce((currentState, pageCode) => (
+  {
+    ...currentState,
+    [pageCode]: { loaded: true, loading: false, expanded: toggleValue },
+  }
+), {});
 
 const statusMap = (state = {}, action = {}) => {
   switch (action.type) {
@@ -199,13 +197,14 @@ const statusMap = (state = {}, action = {}) => {
       return toggleBatchExpandedValues(pageCodes, true);
     }
     case COLLAPSE_ALL: {
-      const newState = {};
       const pageCodes = Object.keys(state);
-      pageCodes.map((p) => {
-        newState[p] = { expanded: false, loading: false, loaded: state[p].loaded };
-        return p;
-      });
-      return newState;
+      return pageCodes.reduce((currentState, pageCode) => {
+        const { loaded } = state[pageCode];
+        return {
+          ...currentState,
+          [pageCode]: { expanded: false, loading: false, loaded },
+        };
+      }, {});
     }
     default: return state;
   }

--- a/src/state/pages/reducer.js
+++ b/src/state/pages/reducer.js
@@ -14,6 +14,8 @@ import {
   SEARCH_PAGES,
   CLEAR_SEARCH,
   CLEAR_TREE,
+  BATCH_TOGGLE_EXPANDED,
+  COLLAPSE_ALL,
 } from 'state/pages/types';
 
 // creates a map from an array
@@ -156,6 +158,15 @@ const titlesMap = (state = {}, action = {}) => {
   }
 };
 
+const toggleBatchExpandedValues = (arr, toggleValue) => {
+  const newState = {};
+  arr.map((pg) => {
+    newState[pg] = { loaded: true, loading: false, expanded: toggleValue };
+    return pg;
+  });
+  return newState;
+};
+
 const statusMap = (state = {}, action = {}) => {
   switch (action.type) {
     case TOGGLE_PAGE_EXPANDED: {
@@ -182,6 +193,19 @@ const statusMap = (state = {}, action = {}) => {
     }
     case CLEAR_TREE: {
       return {};
+    }
+    case BATCH_TOGGLE_EXPANDED: {
+      const pageCodes = action.payload;
+      return toggleBatchExpandedValues(pageCodes, true);
+    }
+    case COLLAPSE_ALL: {
+      const newState = {};
+      const pageCodes = Object.keys(state);
+      pageCodes.map((p) => {
+        newState[p] = { expanded: false, loading: false, loaded: state[p].loaded };
+        return p;
+      });
+      return newState;
     }
     default: return state;
   }

--- a/src/state/pages/types.js
+++ b/src/state/pages/types.js
@@ -12,3 +12,5 @@ export const UPDATE_PAGE = 'pages/update-page';
 export const SEARCH_PAGES = 'pages/search-pages';
 export const CLEAR_SEARCH = 'pages/clear-search';
 export const CLEAR_TREE = 'pages/clear-tree';
+export const BATCH_TOGGLE_EXPANDED = 'pages/set-all-pages-expanded';
+export const COLLAPSE_ALL = 'pages/collapse-all-pages';

--- a/src/ui/pages/common/PageTree.js
+++ b/src/ui/pages/common/PageTree.js
@@ -112,6 +112,26 @@ class PageTree extends Component {
                 <tr>
                   <th width="70%">
                     <FormattedMessage id="pageTree.pageTree" />
+                    <div
+                      onClick={this.props.onExpandAll}
+                      onKeyDown={this.props.onExpandAll}
+                      role="button"
+                      tabIndex={-1}
+                      className="PageTree PageTree__toggler PageTree__toggler--expand"
+                    >
+                      <span className="icon fa fa-plus-square" />
+                      <FormattedMessage id="pageTree.expand" />
+                    </div>
+                    <div
+                      onClick={this.props.onCollapseAll}
+                      onKeyDown={this.props.onCollapseAll}
+                      role="button"
+                      tabIndex={-2}
+                      className="PageTree PageTree__toggler"
+                    >
+                      <span className="icon fa fa-minus-square" />
+                      <FormattedMessage id="pageTree.collapse" />
+                    </div>
                   </th>
                   <th className="text-center" width="10%">
                     <FormattedMessage id="pageTree.status" />
@@ -164,6 +184,8 @@ PageTree.propTypes = {
   onDropAbovePage: PropTypes.func,
   onDropBelowPage: PropTypes.func,
   onExpandPage: PropTypes.func,
+  onExpandAll: PropTypes.func,
+  onCollapseAll: PropTypes.func,
   loading: PropTypes.bool.isRequired,
 };
 
@@ -174,6 +196,8 @@ PageTree.defaultProps = {
   onDropAbovePage: () => {},
   onDropBelowPage: () => {},
   onExpandPage: () => {},
+  onExpandAll: () => {},
+  onCollapseAll: () => {},
 };
 
 export default PageTree;

--- a/src/ui/pages/common/PageTreeContainer.js
+++ b/src/ui/pages/common/PageTreeContainer.js
@@ -23,6 +23,8 @@ import {
   clonePage,
   clearSearchPage,
   initPageForm,
+  fetchPageTreeAll,
+  collapseAll,
 } from 'state/pages/actions';
 
 import { getPageTreePages, getSearchPages } from 'state/pages/selectors';
@@ -84,6 +86,8 @@ export const mapDispatchToProps = dispatch => ({
     dispatch(movePageBelow(sourcePageCode, targetPageCode)),
   onExpandPage: pageCode =>
     dispatch(handleExpandPage(pageCode)),
+  onExpandAll: () => dispatch(fetchPageTreeAll()),
+  onCollapseAll: () => dispatch(collapseAll()),
 });
 
 

--- a/src/ui/pages/common/PageTreeSelectorContainer.js
+++ b/src/ui/pages/common/PageTreeSelectorContainer.js
@@ -3,17 +3,21 @@ import { connect } from 'react-redux';
 
 import { PageTreeSelector } from '@entando/pagetreeselector';
 
-import { handleExpandPage } from 'state/pages/actions';
+import { handleExpandPage, fetchPageTreeAll, collapseAll } from 'state/pages/actions';
 
 import { getPageTreePages } from 'state/pages/selectors';
+import { getLoading } from 'state/loading/selectors';
 
 export const mapStateToProps = (state, { pages }) => ({
   pages: pages || getPageTreePages(state),
+  loading: getLoading(state).pageTree,
 });
 
 export const mapDispatchToProps = dispatch => ({
   onExpandPage: pageCode =>
     dispatch(handleExpandPage(pageCode)),
+  onExpandAll: () => dispatch(fetchPageTreeAll()),
+  onCollapseAll: () => dispatch(collapseAll()),
 });
 
 

--- a/src/ui/pages/config/ContentPages.js
+++ b/src/ui/pages/config/ContentPages.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import { ROUTE_PAGE_ADD } from 'app-init/router';
-import { Icon } from 'patternfly-react';
+import { Icon, Spinner } from 'patternfly-react';
 import PageTreeCompact from 'ui/pages/common/PageTreeCompact';
 import DeletePageModalContainer from 'ui/pages/common/DeletePageModalContainer';
 import PublishPageModalContainer from 'ui/pages/common/PublishPageModalContainer';
@@ -16,6 +16,9 @@ class ContentPages extends Component {
   }
 
   render() {
+    const {
+      loading, onExpandAll, onCollapseAll, onExpandPage, pages,
+    } = this.props;
     return (
       <div className="ContentPages">
         <div className="ContentPages__content-action">
@@ -27,11 +30,35 @@ class ContentPages extends Component {
             <FormattedMessage id="app.add" />
           </Link>
         </div>
-        <PageTreeCompact
-          {...this.props}
-          pages={this.props.pages}
-          onExpandPage={this.props.onExpandPage}
-        />
+        <div className="ContentPages__pagetree-actions">
+          <div
+            onClick={onExpandAll}
+            onKeyDown={onExpandAll}
+            role="button"
+            tabIndex={-1}
+            className="ContentPages__toggler"
+          >
+            <span className="icon fa fa-plus-square" />
+            <FormattedMessage id="pageTree.expand" />
+          </div>
+          <div
+            onClick={onCollapseAll}
+            onKeyDown={onCollapseAll}
+            role="button"
+            tabIndex={-2}
+            className="ContentPages__toggler"
+          >
+            <span className="icon fa fa-minus-square" />
+            <FormattedMessage id="pageTree.collapse" />
+          </div>
+        </div>
+        <Spinner loading={!!loading}>
+          <PageTreeCompact
+            {...this.props}
+            pages={pages}
+            onExpandPage={onExpandPage}
+          />
+        </Spinner>
         <DeletePageModalContainer />
         <PublishPageModalContainer />
         <UnpublishPageModalContainer />
@@ -43,12 +70,18 @@ class ContentPages extends Component {
 ContentPages.propTypes = {
   onWillMount: PropTypes.func,
   onExpandPage: PropTypes.func,
+  onExpandAll: PropTypes.func,
+  onCollapseAll: PropTypes.func,
   pages: PropTypes.arrayOf(PropTypes.shape({})),
+  loading: PropTypes.bool,
 };
 ContentPages.defaultProps = {
   onWillMount: () => {},
   onExpandPage: () => {},
+  onExpandAll: () => {},
+  onCollapseAll: () => {},
   pages: [],
+  loading: false,
 };
 
 export default ContentPages;

--- a/src/ui/pages/config/ContentPagesContainer.js
+++ b/src/ui/pages/config/ContentPagesContainer.js
@@ -17,16 +17,24 @@ import {
   clearSearchPage,
   handleExpandPage,
   initPageForm,
+  fetchPageTreeAll,
+  collapseAll,
+  clearTree,
 } from 'state/pages/actions';
 import { PAGE_INIT_VALUES } from 'ui/pages/common/const';
 import ContentPages from 'ui/pages/config/ContentPages';
+import { getLoading } from 'state/loading/selectors';
 
 export const mapStateToProps = state => ({
   pages: getPageTreePages(state),
+  loading: getLoading(state).pageTree,
 });
 
 export const mapDispatchToProps = dispatch => ({
-  onWillMount: () => dispatch(handleExpandPage()),
+  onWillMount: () => {
+    dispatch(clearTree());
+    dispatch(handleExpandPage());
+  },
   onExpandPage: pageCode =>
     dispatch(handleExpandPage(pageCode)),
   onClickAdd: (page) => {
@@ -66,7 +74,8 @@ export const mapDispatchToProps = dispatch => ({
     dispatch(clonePage(page));
     dispatch(clearSearchPage());
   },
-
+  onExpandAll: () => dispatch(fetchPageTreeAll()),
+  onCollapseAll: () => dispatch(collapseAll()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ContentPages);

--- a/test/state/pages/reducer.test.js
+++ b/test/state/pages/reducer.test.js
@@ -8,7 +8,7 @@ import {
 import {
   addPages, setPageParentSync, movePageSync, togglePageExpanded, setPageLoading, setPageLoaded,
   setFreePages, setSelectedPage, removePage, updatePage, setSearchPages, clearSearch,
-  setReferenceSelectedPage, clearTree,
+  setReferenceSelectedPage, clearTree, collapseAll, setBatchExpanded,
 } from 'state/pages/actions';
 
 const PAGES = [
@@ -290,6 +290,48 @@ describe('state/pages/reducer', () => {
     it('status will be update', () => {
       const newState = reducer(state, setReferenceSelectedPage(CONTENT_REFERENCES));
       expect(newState).toHaveProperty('selected.ref', CONTENT_REFERENCES);
+    });
+  });
+
+  describe('action CLEAR_TREE', () => {
+    let state;
+    beforeEach(() => {
+      state = reducer({}, addPages(PAGES));
+    });
+
+    let newState;
+    it('should clear the tree', () => {
+      newState = reducer(state, clearTree());
+      expect(newState.statusMap).toEqual({});
+    });
+  });
+
+  describe('action COLLAPSE_ALL', () => {
+    let state;
+    beforeEach(() => {
+      state = reducer({}, addPages(PAGES));
+    });
+
+    let newState;
+    it('should collapse all the tree', () => {
+      newState = reducer(state, togglePageExpanded('homepage'));
+      expect(newState.statusMap.homepage.expanded).toBe(true);
+      newState = reducer(newState, collapseAll());
+      Object.values(newState.statusMap).map(v => expect(v.expanded).toBe(false));
+    });
+  });
+
+  describe('action BATCH_TOGGLE_EXPANDED', () => {
+    let state;
+    beforeEach(() => {
+      state = reducer({}, addPages(PAGES));
+    });
+
+    let newState;
+    it('should collapse all the tree', () => {
+      newState = reducer(state, setBatchExpanded(['homepage', 'dashboard']));
+      expect(newState.statusMap.homepage.expanded).toBe(true);
+      expect(newState.statusMap.dashboard.expanded).toBe(true);
     });
   });
 });

--- a/test/ui/pages/common/PageTreeSelectorContainer.test.js
+++ b/test/ui/pages/common/PageTreeSelectorContainer.test.js
@@ -8,6 +8,7 @@ const FAKE_STATE = {
     childrenMap: {},
     titlesMap: {},
   },
+  loading: {},
 };
 
 const dispatchMock = jest.fn();

--- a/test/ui/pages/config/ContentPageContainer.test.js
+++ b/test/ui/pages/config/ContentPageContainer.test.js
@@ -10,6 +10,7 @@ getPageTreePages.mockReturnValue([HOMEPAGE_PAYLOAD]);
 
 const TEST_STATE = {
   pages: HOMEPAGE_PAYLOAD,
+  loading: {},
 };
 
 describe('ContentPagesContainer', () => {


### PR DESCRIPTION
- This PR is markes as `draft` because once `frontend-libraries` has a newer version of `pagetreeselector` its version also needs to be bumped up in `app-builder`.