### PR TITLE
ENG-581 implement route protection for app-builder routes

### DIFF
--- a/src/state/permissions/const.js
+++ b/src/state/permissions/const.js
@@ -1,3 +1,8 @@
 export const ROLE_SUPERUSER = 'superuser';
 export const ADMINISTRATION_AREA_PERMISSION = 'enterBackend';
+export const MANAGE_PAGES_PERMISSION = 'managePages';
+export const CRUD_USERS_PERMISSION = 'editUsers';
+export const VIEW_USERS_AND_PROFILES_PERMISSION = 'viewUsers';
+export const EDIT_USER_PROFILES_PERMISSION = 'editUserProfile';
+export const MANAGE_CATEGORIES_PERMISSION = 'manageCategories';
 

--- a/src/state/permissions/reducer.js
+++ b/src/state/permissions/reducer.js
@@ -1,6 +1,6 @@
 import { combineReducers } from 'redux';
 import { get, flatten } from 'lodash';
-import { ROLE_SUPERUSER } from 'state/permissions/const';
+import { ROLE_SUPERUSER, CRUD_USERS_PERMISSION, VIEW_USERS_AND_PROFILES_PERMISSION, EDIT_USER_PROFILES_PERMISSION } from 'state/permissions/const';
 import {
   SET_PERMISSIONS,
   SET_LOGGED_USER_PERMISSIONS,
@@ -36,7 +36,7 @@ const stringToArr = val => (
   Array.isArray(val) ? val : [val]
 );
 
-const loggedUser = (state = [], action = {}) => {
+const loggedUser = (state = null, action = {}) => {
   switch (action.type) {
     case SET_LOGGED_USER_PERMISSIONS: {
       const { result, allPermissions } = action.payload;
@@ -44,10 +44,15 @@ const loggedUser = (state = [], action = {}) => {
         stringToArr(authority.permissions ? authority.permissions : get(authority, 'role', []))
       ));
       const roles = Array.from(new Set(flatten(authorityMaps)));
+      if (roles.includes(CRUD_USERS_PERMISSION) || roles.includes(EDIT_USER_PROFILES_PERMISSION)) {
+        if (!roles.includes(VIEW_USERS_AND_PROFILES_PERMISSION)) {
+          roles.push(VIEW_USERS_AND_PROFILES_PERMISSION);
+        }
+      }
       return roles.includes(ROLE_SUPERUSER) ? allPermissions : roles;
     }
     case CLEAR_LOGGED_USER_PERMISSIONS:
-      return [];
+      return null;
     default: return state;
   }
 };

--- a/src/state/roles/actions.js
+++ b/src/state/roles/actions.js
@@ -44,17 +44,17 @@ export const setUserRefs = userRefs => ({
 // thunk
 export const fetchRoles = (page = { page: 1, pageSize: 10 }, params = '') => dispatch =>
   new Promise((resolve) => {
+    dispatch(toggleLoading('roles'));
     getRoles(page, params).then((response) => {
       response.json().then((data) => {
         if (response.ok) {
           dispatch(setRoles(data.payload));
-          dispatch(toggleLoading('roles'));
           dispatch(setPage(data.metaData));
         } else {
           dispatch(addErrors(data.errors.map(err => err.message)));
           dispatch(addToast(data.errors[0].message, TOAST_ERROR));
-          dispatch(toggleLoading('roles'));
         }
+        dispatch(toggleLoading('roles'));
         resolve();
       });
     }).catch(() => {});

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -5,7 +5,7 @@ import persistState from 'redux-localstorage';
 
 const localStorageStates = {
   locale: [],
-  permissions: ['loggedUser'],
+  permissions: ['loggedUser', 'loggedUserPemissionsLoaded'],
 };
 
 const composeParams = [

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -5,7 +5,7 @@ import persistState from 'redux-localstorage';
 
 const localStorageStates = {
   locale: [],
-  permissions: ['loggedUser', 'loggedUserPemissionsLoaded'],
+  permissions: ['loggedUser'],
 };
 
 const composeParams = [

--- a/src/ui/auth/withPermissions.js
+++ b/src/ui/auth/withPermissions.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Spinner } from 'patternfly-react';

--- a/src/ui/auth/withPermissions.js
+++ b/src/ui/auth/withPermissions.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Spinner } from 'patternfly-react';
@@ -9,7 +10,6 @@ import { logoutUser } from '@entando/apimanager';
 import { ROUTE_DASHBOARD } from 'app-init/router';
 import { ADMINISTRATION_AREA_PERMISSION } from 'state/permissions/const';
 import { getLoggedUserPermissions } from 'state/permissions/selectors';
-import { getLoading } from 'state/loading/selectors';
 
 /**
  * HOC that Handles whether or not the user is allowed to see the page.
@@ -20,18 +20,18 @@ import { getLoading } from 'state/loading/selectors';
 export default function withPermissions(requiredPermissions) {
   return (WrappedComponent) => {
     const AppBuilderPermissionCheck = ({
-      userPermissions, gotoLogout, gotoHomepage, loading,
+      userPermissions, gotoLogout, gotoHomepage, ...rest
     }) => (
-      <Spinner loading={!!loading}>
+      <Spinner loading={!!(userPermissions === null)}>
         <PermissionCheck
           page403={<NoAccessPage
             gotoHome={requiredPermissions === ADMINISTRATION_AREA_PERMISSION
               ? gotoLogout : gotoHomepage}
           />}
           requiredPermissions={requiredPermissions}
-          userPermissions={userPermissions}
+          userPermissions={userPermissions || []}
         >
-          <WrappedComponent />
+          <WrappedComponent {...rest} />
         </PermissionCheck>
       </Spinner>
     );
@@ -40,24 +40,20 @@ export default function withPermissions(requiredPermissions) {
       userPermissions: PropTypes.arrayOf(PropTypes.string),
       gotoLogout: PropTypes.func.isRequired,
       gotoHomepage: PropTypes.func.isRequired,
-      loading: PropTypes.bool,
     };
 
     AppBuilderPermissionCheck.defaultProps = {
       userPermissions: [],
-      loading: true,
     };
 
     const mapStateToProps = state => ({
       userPermissions: getLoggedUserPermissions(state),
-      loading: getLoading(state).loggedUserPermissions,
     });
 
     const mapDispatchToProps = (dispatch, { history }) => ({
       gotoLogout: () => dispatch(logoutUser()),
       gotoHomepage: () => history.push(routeConverter(ROUTE_DASHBOARD)),
     });
-
 
     return withRouter(connect(mapStateToProps, mapDispatchToProps)(AppBuilderPermissionCheck));
   };

--- a/src/ui/categories/add/AddCategoryPage.js
+++ b/src/ui/categories/add/AddCategoryPage.js
@@ -7,8 +7,10 @@ import PageTitle from 'ui/internal-page/PageTitle';
 import BreadcrumbItem from 'ui/common/BreadcrumbItem';
 import ErrorsAlertContainer from 'ui/common/form/ErrorsAlertContainer';
 import { ROUTE_CATEGORY_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { MANAGE_CATEGORIES_PERMISSION } from 'state/permissions/const';
 
-const AddCategoryPage = () => (
+export const AddCategoryPageBody = () => (
   <InternalPage className="AddCategoryPage">
     <Grid fluid>
       <Row>
@@ -41,4 +43,4 @@ const AddCategoryPage = () => (
   </InternalPage>
 );
 
-export default AddCategoryPage;
+export default withPermissions(MANAGE_CATEGORIES_PERMISSION)(AddCategoryPageBody);

--- a/src/ui/categories/detail/DetailCategoryPage.js
+++ b/src/ui/categories/detail/DetailCategoryPage.js
@@ -7,8 +7,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import DetailCategoryTableContainer from 'ui/categories/detail/DetailCategoryTableContainer';
 import { ROUTE_CATEGORY_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { MANAGE_CATEGORIES_PERMISSION } from 'state/permissions/const';
 
-const DetailCategoryPage = () => (
+export const DetailCategoryPageBody = () => (
   <InternalPage className="DetailCategoryPage">
     <Grid fluid>
       <Row>
@@ -40,4 +42,4 @@ const DetailCategoryPage = () => (
   </InternalPage>
 );
 
-export default DetailCategoryPage;
+export default withPermissions(MANAGE_CATEGORIES_PERMISSION)(DetailCategoryPageBody);

--- a/src/ui/categories/edit/EditCategoryPage.js
+++ b/src/ui/categories/edit/EditCategoryPage.js
@@ -7,8 +7,10 @@ import EditFormContainer from 'ui/categories/edit/EditFormContainer';
 import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import { ROUTE_CATEGORY_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { MANAGE_CATEGORIES_PERMISSION } from 'state/permissions/const';
 
-const EditCategoryPage = () => (
+export const EditCategoryPageBody = () => (
   <InternalPage className="EditCategoryPage">
     <Grid fluid>
       <Row>
@@ -40,4 +42,4 @@ const EditCategoryPage = () => (
   </InternalPage>
 );
 
-export default EditCategoryPage;
+export default withPermissions(MANAGE_CATEGORIES_PERMISSION)(EditCategoryPageBody);

--- a/src/ui/categories/list/ListCategoryPage.js
+++ b/src/ui/categories/list/ListCategoryPage.js
@@ -7,10 +7,11 @@ import BreadcrumbItem from 'ui/common/BreadcrumbItem';
 import CategoryTreeContainer from 'ui/categories/list/CategoryTreeContainer';
 import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
-
+import withPermissions from 'ui/auth/withPermissions';
+import { MANAGE_CATEGORIES_PERMISSION } from 'state/permissions/const';
 import { ROUTE_CATEGORY_ADD } from 'app-init/router';
 
-const ListCategoryPage = () => (
+export const ListCategoryPageBody = () => (
   <InternalPage className="ListCategoryPage">
     <Grid fluid>
       <Row>
@@ -52,4 +53,4 @@ const ListCategoryPage = () => (
   </InternalPage>
 );
 
-export default ListCategoryPage;
+export default withPermissions(MANAGE_CATEGORIES_PERMISSION)(ListCategoryPageBody);

--- a/src/ui/component-repository/components/list/ComponentListPage.js
+++ b/src/ui/component-repository/components/list/ComponentListPage.js
@@ -8,10 +8,11 @@ import FilterTypeContainer from 'ui/component-repository/components/FilterTypeCo
 import CategoryTabBarFilterContainer from 'ui/component-repository/CategoryTabBarFilterContainer';
 import ComponentListContainer from 'ui/component-repository/components/list/ComponentListContainer';
 import ComponentListViewModeSwitcherContainer from 'ui/component-repository/components/common/ComponentListViewModeSwitcherContainer';
-
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 import { ROUTE_ECR_CONFIG_LIST } from 'app-init/router';
 
-const ComponentListPage = () => (
+export const ComponentListPageBody = () => (
   <InternalPage className="ComponentListPage">
     <Grid>
       <Row>
@@ -55,4 +56,4 @@ const ComponentListPage = () => (
   </InternalPage>
 );
 
-export default ComponentListPage;
+export default withPermissions(ROLE_SUPERUSER)(ComponentListPageBody);

--- a/src/ui/data-models/add/AddDataModelPage.js
+++ b/src/ui/data-models/add/AddDataModelPage.js
@@ -8,8 +8,10 @@ import PageTitle from 'ui/internal-page/PageTitle';
 import ErrorsAlertContainer from 'ui/common/form/ErrorsAlertContainer';
 import AddDataModelFormContainer from 'ui/data-models/add/AddDataModelFormContainer';
 import { ROUTE_DATA_MODEL_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const AddDataModelPage = () => (
+export const AddDataModelPageBody = () => (
   <InternalPage className="AddDataModelPage">
     <Grid fluid>
       <Row>
@@ -41,4 +43,4 @@ const AddDataModelPage = () => (
   </InternalPage>
 );
 
-export default AddDataModelPage;
+export default withPermissions(ROLE_SUPERUSER)(AddDataModelPageBody);

--- a/src/ui/data-models/edit/EditDataModelPage.js
+++ b/src/ui/data-models/edit/EditDataModelPage.js
@@ -8,8 +8,10 @@ import PageTitle from 'ui/internal-page/PageTitle';
 import ErrorsAlertContainer from 'ui/common/form/ErrorsAlertContainer';
 import DataModelFormContainer from 'ui/data-models/edit/EditDataModelFormContainer';
 import { ROUTE_DATA_MODEL_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const EditDataModelPage = () => (
+export const EditDataModelPageBody = () => (
   <InternalPage className="EditDataModelPage">
     <Grid fluid>
       <Row>
@@ -41,4 +43,4 @@ const EditDataModelPage = () => (
   </InternalPage>
 );
 
-export default EditDataModelPage;
+export default withPermissions(ROLE_SUPERUSER)(EditDataModelPageBody);

--- a/src/ui/data-models/list/DataModelListPage.js
+++ b/src/ui/data-models/list/DataModelListPage.js
@@ -9,6 +9,8 @@ import DataModelListTableContainer from 'ui/data-models/list/DataModelListTableC
 import PageTitle from 'ui/internal-page/PageTitle';
 import BreadcrumbItem from 'ui/common/BreadcrumbItem';
 import { ROUTE_DATA_MODEL_ADD } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 const DataModelListPage = () => (
   <InternalPage className="DataModelListPage">
@@ -57,4 +59,4 @@ const DataModelListPage = () => (
   </InternalPage>
 );
 
-export default DataModelListPage;
+export default withPermissions(ROLE_SUPERUSER)(DataModelListPage);

--- a/src/ui/data-types/add/AddDataTypesPage.js
+++ b/src/ui/data-types/add/AddDataTypesPage.js
@@ -7,7 +7,8 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import AddFormContainer from 'ui/data-types/add/AddFormContainer';
 import { ROUTE_DATA_TYPE_LIST } from 'app-init/router';
-
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 const AddDataTypesPage = () => (
   <InternalPage className="AddDataTypesPage">
@@ -40,4 +41,4 @@ const AddDataTypesPage = () => (
   </InternalPage>
 );
 
-export default AddDataTypesPage;
+export default withPermissions(ROLE_SUPERUSER)(AddDataTypesPage);

--- a/src/ui/data-types/attributes/AddDataTypeAttributePage.js
+++ b/src/ui/data-types/attributes/AddDataTypeAttributePage.js
@@ -8,6 +8,8 @@ import PageTitle from 'ui/internal-page/PageTitle';
 import ErrorsAlertContainer from 'ui/common/form/ErrorsAlertContainer';
 import AddFormContainer from 'ui/data-types/attributes/AddFormContainer';
 import { ROUTE_DATA_TYPE_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 const msgs = defineMessages({
   add: {
@@ -57,4 +59,4 @@ AddDataTypeAttributePage.propTypes = {
   intl: intlShape.isRequired,
 };
 
-export default injectIntl(AddDataTypeAttributePage);
+export default withPermissions(ROLE_SUPERUSER)(injectIntl(AddDataTypeAttributePage));

--- a/src/ui/data-types/attributes/EditDataTypeAttributePage.js
+++ b/src/ui/data-types/attributes/EditDataTypeAttributePage.js
@@ -8,6 +8,8 @@ import PageTitle from 'ui/internal-page/PageTitle';
 import ErrorsAlertContainer from 'ui/common/form/ErrorsAlertContainer';
 import EditFormContainer from 'ui/data-types/attributes/EditFormContainer';
 import { ROUTE_DATA_TYPE_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 const msgs = defineMessages({
   edit: {
@@ -58,4 +60,4 @@ EditDataTypeAttributePage.propTypes = {
   intl: intlShape.isRequired,
 };
 
-export default injectIntl(EditDataTypeAttributePage);
+export default withPermissions(ROLE_SUPERUSER)(injectIntl(EditDataTypeAttributePage));

--- a/src/ui/data-types/edit/EditDataTypesPage.js
+++ b/src/ui/data-types/edit/EditDataTypesPage.js
@@ -7,7 +7,8 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import EditFormContainer from 'ui/data-types/edit/EditFormContainer';
 import { ROUTE_DATA_TYPE_LIST } from 'app-init/router';
-
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 const EditDataTypesPage = () => (
   <InternalPage className="EditDataTypesPage">
@@ -40,4 +41,4 @@ const EditDataTypesPage = () => (
   </InternalPage>
 );
 
-export default EditDataTypesPage;
+export default withPermissions(ROLE_SUPERUSER)(EditDataTypesPage);

--- a/src/ui/data-types/list/ListDataTypePage.js
+++ b/src/ui/data-types/list/ListDataTypePage.js
@@ -8,8 +8,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import DataTypeListTableContainer from 'ui/data-types/list/DataTypeListTableContainer';
 import { ROUTE_DATA_TYPE_ADD } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const ListDataTypePage = () => (
+export const ListDataTypePageBody = () => (
   <InternalPage className="ListDataTypePage">
     <Grid fluid>
       <Row>
@@ -48,4 +50,4 @@ const ListDataTypePage = () => (
   </InternalPage>
 );
 
-export default ListDataTypePage;
+export default withPermissions(ROLE_SUPERUSER)(ListDataTypePageBody);

--- a/src/ui/database/add/AddDatabasePageContainer.js
+++ b/src/ui/database/add/AddDatabasePageContainer.js
@@ -9,8 +9,8 @@ export const mapDispatchToProps = dispatch => ({
 });
 
 
-const AddDatabasePageContainer = withPermissions(ROLE_SUPERUSER)(connect(
+const AddDatabasePageContainer = connect(
   null,
   mapDispatchToProps,
-)(AddDatabasePage));
-export default AddDatabasePageContainer;
+)(AddDatabasePage);
+export default withPermissions(ROLE_SUPERUSER)(AddDatabasePageContainer);

--- a/src/ui/database/add/AddDatabasePageContainer.js
+++ b/src/ui/database/add/AddDatabasePageContainer.js
@@ -1,12 +1,16 @@
 import { connect } from 'react-redux';
 import AddDatabasePage from 'ui/database/add/AddDatabasePage';
 import { fetchDatabaseInitBackup } from 'state/database/actions';
-
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 export const mapDispatchToProps = dispatch => ({
   onWillMount: () => dispatch(fetchDatabaseInitBackup()),
 });
 
 
-const AddDatabasePageContainer = connect(null, mapDispatchToProps)(AddDatabasePage);
+const AddDatabasePageContainer = withPermissions(ROLE_SUPERUSER)(connect(
+  null,
+  mapDispatchToProps,
+)(AddDatabasePage));
 export default AddDatabasePageContainer;

--- a/src/ui/database/dump/DatabaseDumpTablePageContainer.js
+++ b/src/ui/database/dump/DatabaseDumpTablePageContainer.js
@@ -2,6 +2,8 @@ import { connect } from 'react-redux';
 import { fetchDatabaseDumpTable } from 'state/database/actions';
 import DatabaseDumpTablePage from 'ui/database/dump/DatabaseDumpTablePage';
 import { getTableDumpData } from 'state/database/selectors';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 export const mapStateToProps = state => ({
   dumpData: getTableDumpData(state),
@@ -15,4 +17,4 @@ export const mapDispatchToProps = dispatch => ({
 
 const DatabaseDumpTablePageContainer =
   connect(mapStateToProps, mapDispatchToProps)(DatabaseDumpTablePage);
-export default DatabaseDumpTablePageContainer;
+export default withPermissions(ROLE_SUPERUSER)(DatabaseDumpTablePageContainer);

--- a/src/ui/database/list/ListDatabasePage.js
+++ b/src/ui/database/list/ListDatabasePage.js
@@ -7,10 +7,11 @@ import BreadcrumbItem from 'ui/common/BreadcrumbItem';
 import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import DatabaseListTableContainer from 'ui/database/list/DatabaseListTableContainer';
-
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 import { ROUTE_DATABASE_ADD } from 'app-init/router';
 
-const DatabaseListPage = () => (
+export const DatabaseListPageBody = () => (
   <InternalPage className="DatabaseListPage">
     <Grid fluid>
       <Row>
@@ -51,4 +52,4 @@ const DatabaseListPage = () => (
   </InternalPage>
 );
 
-export default DatabaseListPage;
+export default withPermissions(ROLE_SUPERUSER)(DatabaseListPageBody);

--- a/src/ui/database/report/ReportDatabasePageContainer.js
+++ b/src/ui/database/report/ReportDatabasePageContainer.js
@@ -18,7 +18,9 @@ export const mapDispatchToProps = (dispatch, { match: { params } }) => ({
   },
 });
 
-export default withRouter(connect(
+const ReportDatabasePageContainer = withRouter(connect(
   mapStateToProps,
   mapDispatchToProps,
-)(withPermissions(ROLE_SUPERUSER)(ReportDatabasePage)));
+)(ReportDatabasePage));
+
+export default withPermissions(ROLE_SUPERUSER)(ReportDatabasePageContainer);

--- a/src/ui/database/report/ReportDatabasePageContainer.js
+++ b/src/ui/database/report/ReportDatabasePageContainer.js
@@ -4,6 +4,8 @@ import { getLoading } from 'state/loading/selectors';
 import { fetchDatabaseReportBackup } from 'state/database/actions';
 import { getDatabaseReportBackup } from 'state/database/selectors';
 import ReportDatabasePage from 'ui/database/report/ReportDatabasePage';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 export const mapStateToProps = state => ({
   report: getDatabaseReportBackup(state),
@@ -16,4 +18,7 @@ export const mapDispatchToProps = (dispatch, { match: { params } }) => ({
   },
 });
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(ReportDatabasePage));
+export default withRouter(connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(withPermissions(ROLE_SUPERUSER)(ReportDatabasePage)));

--- a/src/ui/file-browser/add/CreateFolderPage.js
+++ b/src/ui/file-browser/add/CreateFolderPage.js
@@ -8,9 +8,10 @@ import PageTitle from 'ui/internal-page/PageTitle';
 import FileBreadcrumbContainer from 'ui/file-browser/common/FileBreadcrumbContainer';
 import FileButtonsGroupContainer from 'ui/file-browser/common/FileButtonsGroupContainer';
 import CreateFolderFormContainer from 'ui/file-browser/add/CreateFolderFormContainer';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-
-const CreateFolderPage = () => (
+export const CreateFolderPageBody = () => (
   <InternalPage className="CreateFolderPage">
     <Grid fluid>
       <Row>
@@ -56,4 +57,4 @@ const CreateFolderPage = () => (
   </InternalPage>
 );
 
-export default CreateFolderPage;
+export default withPermissions(ROLE_SUPERUSER)(CreateFolderPageBody);

--- a/src/ui/file-browser/add/CreateTextFilePage.js
+++ b/src/ui/file-browser/add/CreateTextFilePage.js
@@ -8,7 +8,8 @@ import PageTitle from 'ui/internal-page/PageTitle';
 import FileBreadcrumbContainer from 'ui/file-browser/common/FileBreadcrumbContainer';
 import FileButtonsGroupContainer from 'ui/file-browser/common/FileButtonsGroupContainer';
 import CreateTextFileFormContainer from 'ui/file-browser/add/CreateTextFileFormContainer';
-
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 const CreateTextFilePage = () => (
   <InternalPage className="CreateTextFilePage">
@@ -56,4 +57,4 @@ const CreateTextFilePage = () => (
   </InternalPage>
 );
 
-export default CreateTextFilePage;
+export default withPermissions(ROLE_SUPERUSER)(CreateTextFilePage);

--- a/src/ui/file-browser/edit/EditTextFilePage.js
+++ b/src/ui/file-browser/edit/EditTextFilePage.js
@@ -7,9 +7,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import FileBreadcrumbContainer from 'ui/file-browser/common/FileBreadcrumbContainer';
 import EditTextFileFormContainer from 'ui/file-browser/edit/EditTextFileFormContainer';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-
-const EditTextFilePage = () => (
+export const EditTextFilePageBody = () => (
   <InternalPage className="EditTextFilePage">
     <Grid fluid>
       <Row>
@@ -52,4 +53,4 @@ const EditTextFilePage = () => (
   </InternalPage>
 );
 
-export default EditTextFilePage;
+export default withPermissions(ROLE_SUPERUSER)(EditTextFilePageBody);

--- a/src/ui/file-browser/list/ListFilesPage.js
+++ b/src/ui/file-browser/list/ListFilesPage.js
@@ -9,8 +9,10 @@ import PageTitle from 'ui/internal-page/PageTitle';
 import FilesListTableContainer from 'ui/file-browser/list/FilesListTableContainer';
 import FileBreadcrumbContainer from 'ui/file-browser/common/FileBreadcrumbContainer';
 import FileButtonsGroupContainer from 'ui/file-browser/common/FileButtonsGroupContainer';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const ListFilesPage = () => (
+export const ListFilesPageBody = () => (
   <InternalPage className="ListFilesPage">
     <Grid fluid>
       <Row>
@@ -51,4 +53,4 @@ const ListFilesPage = () => (
   </InternalPage>
 );
 
-export default ListFilesPage;
+export default withPermissions(ROLE_SUPERUSER)(ListFilesPageBody);

--- a/src/ui/file-browser/upload/UploadFileBrowserPage.js
+++ b/src/ui/file-browser/upload/UploadFileBrowserPage.js
@@ -10,11 +10,12 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import UploadFileBrowserFormContainer from 'ui/file-browser/upload/UploadFileBrowserFormContainer';
 import FileBreadcrumbContainer from 'ui/file-browser/common/FileBreadcrumbContainer';
-
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 import { ROUTE_FILE_BROWSER, ROUTE_FILE_BROWSER_UPLOAD } from 'app-init/router';
 
 
-const UploadFileBrowserPage = ({ location: { pathname } }) => {
+export const UploadFileBrowserPageBody = ({ location: { pathname } }) => {
   const uploadFileButton = (
     <Button
       type="button"
@@ -103,10 +104,10 @@ const UploadFileBrowserPage = ({ location: { pathname } }) => {
   );
 };
 
-UploadFileBrowserPage.propTypes = {
+UploadFileBrowserPageBody.propTypes = {
   location: PropTypes.shape({
     pathname: PropTypes.string.isRequired,
   }).isRequired,
 };
 
-export default UploadFileBrowserPage;
+export default withPermissions(ROLE_SUPERUSER)(UploadFileBrowserPageBody);

--- a/src/ui/fragments/add/AddFormContainer.js
+++ b/src/ui/fragments/add/AddFormContainer.js
@@ -15,6 +15,9 @@ export const mapDispatchToProps = (dispatch, { history }) => ({
   onDiscard: () => { dispatch(setVisibleModal('')); history.push(routeConverter(ROUTE_FRAGMENT_LIST)); },
 });
 
-export default withRouter(connect(null, mapDispatchToProps, null, {
-  pure: false,
-})(FragmentForm));
+export default withRouter(connect(
+  null,
+  mapDispatchToProps, null, {
+    pure: false,
+  },
+)(FragmentForm));

--- a/src/ui/fragments/add/AddFragmentPage.js
+++ b/src/ui/fragments/add/AddFragmentPage.js
@@ -7,8 +7,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import AddFormContainer from 'ui/fragments/add/AddFormContainer';
 import { ROUTE_FRAGMENT_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const AddFragmentPage = () => (
+export const AddFragmentPageBody = () => (
 
   <InternalPage className="AddFragmentPage">
     <Grid fluid>
@@ -41,4 +43,4 @@ const AddFragmentPage = () => (
 );
 
 
-export default AddFragmentPage;
+export default withPermissions(ROLE_SUPERUSER)(AddFragmentPageBody);

--- a/src/ui/fragments/detail/DetailFragmentPageContainer.js
+++ b/src/ui/fragments/detail/DetailFragmentPageContainer.js
@@ -5,6 +5,8 @@ import DetailFragmentPage from 'ui/fragments/detail/DetailFragmentPage';
 import { fetchFragmentDetail } from 'state/fragments/actions';
 import { getFragmentSelected } from 'state/fragments/selectors';
 import { history, ROUTE_FRAGMENT_EDIT } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 export const mapStateToProps = (state, { match: { params } }) => ({
   code: params.fragmentCode,
@@ -23,4 +25,7 @@ export const mapDispatchToProps = dispatch => ({
 
 });
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(DetailFragmentPage));
+export default withRouter(connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(withPermissions(ROLE_SUPERUSER)(DetailFragmentPage)));

--- a/src/ui/fragments/edit/EditFragmentPageContainer.js
+++ b/src/ui/fragments/edit/EditFragmentPageContainer.js
@@ -3,6 +3,8 @@ import { withRouter } from 'react-router-dom';
 
 import EditFragmentPage from 'ui/fragments/edit/EditFragmentPage';
 import { fetchFragment } from 'state/fragments/actions';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 export const mapStateToProps = (state, { match: { params } }) => (
   {
@@ -15,4 +17,7 @@ export const mapDispatchToProps = dispatch => ({
   },
 });
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(EditFragmentPage));
+export default withRouter(connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(withPermissions(ROLE_SUPERUSER)(EditFragmentPage)));

--- a/src/ui/fragments/list/ListFragmentPage.js
+++ b/src/ui/fragments/list/ListFragmentPage.js
@@ -7,12 +7,13 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import SettingsFragmentFormContainer from 'ui/fragments/list/SettingsFragmentFormContainer';
 import FragmentListContent from 'ui/fragments/list/FragmentListContent';
-
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 const TAB_LIST = 'list';
 const TAB_SETTINGS = 'settings';
 
-class ListFragmentPage extends Component {
+export class ListFragmentPageBody extends Component {
   constructor(props) {
     super(props);
     this.setActiveTab = this.setActiveTab.bind(this);
@@ -81,4 +82,4 @@ class ListFragmentPage extends Component {
   }
 }
 
-export default ListFragmentPage;
+export default withPermissions(ROLE_SUPERUSER)(ListFragmentPageBody);

--- a/src/ui/groups/add/AddGroupPage.js
+++ b/src/ui/groups/add/AddGroupPage.js
@@ -7,8 +7,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import AddFormContainer from 'ui/groups/add/AddFormContainer';
 import { ROUTE_GROUP_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const AddGroupPage = () => (
+export const AddGroupPageBody = () => (
 
   <InternalPage className="AddGroupPage">
     <Grid fluid>
@@ -41,4 +43,4 @@ const AddGroupPage = () => (
 );
 
 
-export default AddGroupPage;
+export default withPermissions(ROLE_SUPERUSER)(AddGroupPageBody);

--- a/src/ui/groups/detail/DetailGroupPage.js
+++ b/src/ui/groups/detail/DetailGroupPage.js
@@ -7,8 +7,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import GroupDetailTableContainer from 'ui/groups/detail/GroupDetailTableContainer';
 import { ROUTE_GROUP_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const DetailGroupPage = () => (
+export const DetailGroupPageBody = () => (
   <InternalPage className="DetailGroupPage">
     <Grid fluid>
       <Row>
@@ -43,4 +45,4 @@ const DetailGroupPage = () => (
   </InternalPage>
 );
 
-export default DetailGroupPage;
+export default withPermissions(ROLE_SUPERUSER)(DetailGroupPageBody);

--- a/src/ui/groups/edit/EditGroupPage.js
+++ b/src/ui/groups/edit/EditGroupPage.js
@@ -7,8 +7,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import EditFormContainer from 'ui/groups/edit/EditFormContainer';
 import { ROUTE_GROUP_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const EditGroupPage = () => (
+export const EditGroupPageBody = () => (
 
   <InternalPage className="EditGroupPage">
     <Grid fluid>
@@ -41,4 +43,4 @@ const EditGroupPage = () => (
 );
 
 
-export default EditGroupPage;
+export default withPermissions(ROLE_SUPERUSER)(EditGroupPageBody);

--- a/src/ui/groups/list/ListGroupPage.js
+++ b/src/ui/groups/list/ListGroupPage.js
@@ -9,8 +9,10 @@ import PageTitle from 'ui/internal-page/PageTitle';
 import GroupListTableContainer from 'ui/groups/list/GroupListTableContainer';
 import ErrorsAlertContainer from 'ui/common/form/ErrorsAlertContainer';
 import { ROUTE_GROUP_ADD } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const ListGroupPage = () => (
+export const ListGroupPageBody = () => (
   <InternalPage className="ListGroupPage">
     <Grid fluid>
       <Row>
@@ -60,4 +62,4 @@ const ListGroupPage = () => (
   </InternalPage>
 );
 
-export default ListGroupPage;
+export default withPermissions(ROLE_SUPERUSER)(ListGroupPageBody);

--- a/src/ui/labels/add/AddLabelPage.js
+++ b/src/ui/labels/add/AddLabelPage.js
@@ -7,8 +7,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import AddFormContainer from 'ui/labels/add/AddFormContainer';
 import { ROUTE_LABELS_AND_LANGUAGES } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const AddLabelPage = () => (
+export const AddLabelPageBody = () => (
   <InternalPage className="AddLabelPage">
     <Grid fluid>
       <Row>
@@ -47,4 +49,4 @@ const AddLabelPage = () => (
 );
 
 
-export default AddLabelPage;
+export default withPermissions(ROLE_SUPERUSER)(AddLabelPageBody);

--- a/src/ui/labels/edit/EditLabelPage.js
+++ b/src/ui/labels/edit/EditLabelPage.js
@@ -7,8 +7,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import EditFormContainer from 'ui/labels/edit/EditFormContainer';
 import { ROUTE_LABELS_AND_LANGUAGES } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const EditLabelsPage = () => (
+export const EditLabelPageBody = () => (
   <InternalPage className="EditLabelsPage">
     <Grid fluid>
       <Row>
@@ -46,4 +48,4 @@ const EditLabelsPage = () => (
   </InternalPage>
 );
 
-export default EditLabelsPage;
+export default withPermissions(ROLE_SUPERUSER)(EditLabelPageBody);

--- a/src/ui/labels/list/LabelsAndLanguagesPageContainer.js
+++ b/src/ui/labels/list/LabelsAndLanguagesPageContainer.js
@@ -6,6 +6,8 @@ import { fetchLabels, setActiveTab } from 'state/labels/actions';
 import { getCurrentPage, getTotalItems, getPageSize } from 'state/pagination/selectors';
 import { getActiveTab } from 'state/labels/selectors';
 import { getLoading } from 'state/loading/selectors';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 const TAB_LANGUAGES = 'languages';
 
@@ -31,4 +33,4 @@ export const mapDispatchToProps = dispatch => ({
 const LabelsAndLanguagesPageContainer =
   connect(mapStateToProps, mapDispatchToProps)(LabelsAndLanguagesPage);
 
-export default LabelsAndLanguagesPageContainer;
+export default withPermissions(ROLE_SUPERUSER)(LabelsAndLanguagesPageContainer);

--- a/src/ui/page-templates/add/PageTemplateAddPage.js
+++ b/src/ui/page-templates/add/PageTemplateAddPage.js
@@ -8,8 +8,10 @@ import PageTitle from 'ui/internal-page/PageTitle';
 import PageTemplateFormContainer from 'ui/page-templates/common/PageTemplateFormContainer';
 import ErrorsAlertContainer from 'ui/common/form/ErrorsAlertContainer';
 import { ROUTE_PAGE_TEMPLATE_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const PageTemplateAddPage = () => (
+export const PageTemplateAddPageBody = () => (
   <InternalPage className="PageTemplateAddPage">
     <Grid fluid>
       <Row>
@@ -46,4 +48,4 @@ const PageTemplateAddPage = () => (
   </InternalPage>
 );
 
-export default PageTemplateAddPage;
+export default withPermissions(ROLE_SUPERUSER)(PageTemplateAddPageBody);

--- a/src/ui/page-templates/detail/PageTemplateDetailPage.js
+++ b/src/ui/page-templates/detail/PageTemplateDetailPage.js
@@ -11,8 +11,10 @@ import PageTitle from 'ui/internal-page/PageTitle';
 import SelectedPageTemplateDetailTableContainer from 'ui/page-templates/detail/SelectedPageTemplateDetailTableContainer';
 import PageTemplatePageReferencesTableContainer from 'ui/page-templates/detail/PageTemplatePageReferencesTableContainer';
 import { ROUTE_PAGE_TEMPLATE_LIST, ROUTE_PAGE_TEMPLATE_EDIT } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const PageTemplateDetailPage = ({ pageTemplateCode }) => (
+export const PageTemplateDetailPageBody = ({ pageTemplateCode }) => (
   <InternalPage className="PageTemplateDetailPage">
     <Grid fluid>
       <Row>
@@ -67,8 +69,8 @@ const PageTemplateDetailPage = ({ pageTemplateCode }) => (
   </InternalPage>
 );
 
-PageTemplateDetailPage.propTypes = {
+PageTemplateDetailPageBody.propTypes = {
   pageTemplateCode: PropTypes.string.isRequired,
 };
 
-export default PageTemplateDetailPage;
+export default withPermissions(ROLE_SUPERUSER)(PageTemplateDetailPageBody);

--- a/src/ui/page-templates/detail/PageTemplatePageReferencesTable.js
+++ b/src/ui/page-templates/detail/PageTemplatePageReferencesTable.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { FormattedMessage, defineMessages, injectIntl, intlShape } from 'react-intl';
-import { DropdownKebab, Paginator, Spinner } from 'patternfly-react';
+import { DropdownKebab, Paginator, Spinner, MenuItem } from 'patternfly-react';
 import { Table, Alert } from 'react-bootstrap';
 import { routeConverter } from '@entando/utils';
 
@@ -36,20 +36,24 @@ class PageTemplatePageReferencesTable extends Component {
         <td>{item.fullTitle}</td>
         <td className="text-center">
           <DropdownKebab id={`kebab-${item.code}`} pullRight>
-            <Link
-              id={`goto-${item.code}`}
-              to={routeConverter(ROUTE_PAGE_EDIT, { pageCode: item.code })}
-              className="PageTemplatePageReferencesTable__menu-item-goto"
-            >
-              {`${goTo} ${item.title}`}
-            </Link>
-            <Link
-              id={`page-configuration-${item.code}`}
-              to={routeConverter(ROUTE_PAGE_CONFIG, { pageCode: item.code })}
-              className="PageTemplatePageReferencesTable__menu-item-config"
-            >
-              {`${pageConfiguration} ${item.title}`}
-            </Link>
+            <MenuItem>
+              <Link
+                id={`goto-${item.code}`}
+                to={routeConverter(ROUTE_PAGE_EDIT, { pageCode: item.code })}
+                className="PageTemplatePageReferencesTable__menu-item-goto"
+              >
+                {`${goTo} ${item.title}`}
+              </Link>
+            </MenuItem>
+            <MenuItem>
+              <Link
+                id={`page-configuration-${item.code}`}
+                to={routeConverter(ROUTE_PAGE_CONFIG, { pageCode: item.code })}
+                className="PageTemplatePageReferencesTable__menu-item-config"
+              >
+                {`${pageConfiguration} ${item.title}`}
+              </Link>
+            </MenuItem>
           </DropdownKebab>
         </td>
       </tr>

--- a/src/ui/page-templates/edit/PageTemplateEditPage.js
+++ b/src/ui/page-templates/edit/PageTemplateEditPage.js
@@ -8,8 +8,10 @@ import PageTitle from 'ui/internal-page/PageTitle';
 import PageTemplateFormContainer from 'ui/page-templates/common/PageTemplateFormContainer';
 import ErrorsAlertContainer from 'ui/common/form/ErrorsAlertContainer';
 import { ROUTE_PAGE_TEMPLATE_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const PageTemplateEditPage = () => (
+export const PageTemplateEditPageBody = () => (
   <InternalPage className="PageTemplateEditPage">
     <Grid fluid>
       <Row>
@@ -46,4 +48,4 @@ const PageTemplateEditPage = () => (
   </InternalPage>
 );
 
-export default PageTemplateEditPage;
+export default withPermissions(ROLE_SUPERUSER)(PageTemplateEditPageBody);

--- a/src/ui/page-templates/list/PageTemplateListPage.js
+++ b/src/ui/page-templates/list/PageTemplateListPage.js
@@ -8,8 +8,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import PageTemplateListTableContainer from 'ui/page-templates/list/PageTemplateListTableContainer';
 import { ROUTE_PAGE_TEMPLATE_ADD } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const PageTemplateListPage = () => (
+export const PageTemplateListPageBody = () => (
   <InternalPage className="PageTemplateListPage">
     <Grid fluid>
       <Row>
@@ -55,4 +57,4 @@ const PageTemplateListPage = () => (
   </InternalPage>
 );
 
-export default PageTemplateListPage;
+export default withPermissions(ROLE_SUPERUSER)(PageTemplateListPageBody);

--- a/src/ui/pages/add/PagesAddFormContainer.js
+++ b/src/ui/pages/add/PagesAddFormContainer.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import { connect } from 'react-redux';
 import { formValueSelector, change } from 'redux-form';
 import { routeConverter } from '@entando/utils';

--- a/src/ui/pages/add/PagesAddPageContainer.js
+++ b/src/ui/pages/add/PagesAddPageContainer.js
@@ -4,7 +4,8 @@ import PagesAddPage from 'ui/pages/add/PagesAddPage';
 import { fetchGroups } from 'state/groups/actions';
 import { fetchPageTemplates } from 'state/page-templates/actions';
 import { handleExpandPage, clearTree } from 'state/pages/actions';
-
+import withPermissions from 'ui/auth/withPermissions';
+import { MANAGE_PAGES_PERMISSION } from 'state/permissions/const';
 
 export const mapDispatchToProps = dispatch => ({
   onWillMount: () => {
@@ -19,4 +20,4 @@ export const mapDispatchToProps = dispatch => ({
 const PagesAddPageContainer = connect(null, mapDispatchToProps)(PagesAddPage);
 
 
-export default PagesAddPageContainer;
+export default withPermissions(MANAGE_PAGES_PERMISSION)(PagesAddPageContainer);

--- a/src/ui/pages/clone/PagesClonePage.js
+++ b/src/ui/pages/clone/PagesClonePage.js
@@ -8,9 +8,10 @@ import PageTitle from 'ui/internal-page/PageTitle';
 import CloneFormContainer from 'ui/pages/clone/CloneFormContainer';
 import ErrorsAlertContainer from 'ui/common/form/ErrorsAlertContainer';
 import { ROUTE_PAGE_TREE } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { MANAGE_PAGES_PERMISSION } from 'state/permissions/const';
 
-
-const PagesClonePage = () => (
+export const PagesClonePageBody = () => (
   <InternalPage className="PagesClonePage">
     <Grid fluid>
       <Row>
@@ -47,4 +48,4 @@ const PagesClonePage = () => (
   </InternalPage>
 );
 
-export default PagesClonePage;
+export default withPermissions(MANAGE_PAGES_PERMISSION)(PagesClonePageBody);

--- a/src/ui/pages/config/PageConfigPageContainer.js
+++ b/src/ui/pages/config/PageConfigPageContainer.js
@@ -15,6 +15,8 @@ import { getLocale } from 'state/locale/selectors';
 import { setVisibleModal } from 'state/modal/actions';
 import { MODAL_ID } from 'ui/pages/config/SinglePageSettingsModal';
 import { getLoading } from 'state/loading/selectors';
+import withPermissions from 'ui/auth/withPermissions';
+import { MANAGE_PAGES_PERMISSION } from 'state/permissions/const';
 
 export const mapDispatchToProps = (dispatch, { match: { params } }) => ({
   onWillMount: (pageCode) => {
@@ -49,11 +51,10 @@ export const mapStateToProps = (state, { match: { params } }) => {
   };
 };
 
-
 const PageConfigPageContainer = connect(
   mapStateToProps, mapDispatchToProps, null,
   {
     pure: false,
   },
 )(PageConfigPage);
-export default PageConfigPageContainer;
+export default withPermissions(MANAGE_PAGES_PERMISSION)(PageConfigPageContainer);

--- a/src/ui/pages/detail/PagesDetailPageContainer.js
+++ b/src/ui/pages/detail/PagesDetailPageContainer.js
@@ -18,7 +18,9 @@ export const mapDispatchToProps = dispatch => ({
     }),
 });
 
-export default withRouter(connect(
+const PagesDetailPageContainer = withRouter(connect(
   mapStateToProps,
   mapDispatchToProps,
-)(withPermissions(MANAGE_PAGES_PERMISSION)(PagesDetailPage)));
+)(PagesDetailPage));
+
+export default withPermissions(MANAGE_PAGES_PERMISSION)(PagesDetailPageContainer);

--- a/src/ui/pages/detail/PagesDetailPageContainer.js
+++ b/src/ui/pages/detail/PagesDetailPageContainer.js
@@ -3,6 +3,8 @@ import { withRouter } from 'react-router-dom';
 import PagesDetailPage from 'ui/pages/detail/PagesDetailPage';
 import { loadSelectedPage, setReferenceSelectedPage } from 'state/pages/actions';
 import { getReferencesFromSelectedPage } from 'state/pages/selectors';
+import withPermissions from 'ui/auth/withPermissions';
+import { MANAGE_PAGES_PERMISSION } from 'state/permissions/const';
 
 export const mapStateToProps = (state, { match: { params } }) => ({
   pageCode: params.pageCode,
@@ -16,4 +18,7 @@ export const mapDispatchToProps = dispatch => ({
     }),
 });
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(PagesDetailPage));
+export default withRouter(connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(withPermissions(MANAGE_PAGES_PERMISSION)(PagesDetailPage)));

--- a/src/ui/pages/edit/PagesEditPage.js
+++ b/src/ui/pages/edit/PagesEditPage.js
@@ -9,9 +9,10 @@ import PageTitle from 'ui/internal-page/PageTitle';
 import PagesEditFormContainer from 'ui/pages/edit/PagesEditFormContainer';
 import ErrorsAlertContainer from 'ui/common/form/ErrorsAlertContainer';
 import { ROUTE_PAGE_TREE } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { MANAGE_PAGES_PERMISSION } from 'state/permissions/const';
 
-
-class PagesEditPage extends Component {
+export class PagesEditPageBody extends Component {
   componentWillMount() {
     if (this.props.onWillMount) this.props.onWillMount(this.props);
   }
@@ -56,12 +57,12 @@ class PagesEditPage extends Component {
   }
 }
 
-PagesEditPage.propTypes = {
+PagesEditPageBody.propTypes = {
   onWillMount: PropTypes.func,
 };
 
-PagesEditPage.defaultProps = {
+PagesEditPageBody.defaultProps = {
   onWillMount: null,
 };
 
-export default PagesEditPage;
+export default withPermissions(MANAGE_PAGES_PERMISSION)(PagesEditPageBody);

--- a/src/ui/pages/list/PageTreePageContainer.js
+++ b/src/ui/pages/list/PageTreePageContainer.js
@@ -7,6 +7,8 @@ import { getLocale } from 'state/locale/selectors';
 import { getSearchPages } from 'state/pages/selectors';
 import { toggleLoading } from 'state/loading/actions';
 import { getLoading } from 'state/loading/selectors';
+import withPermissions from 'ui/auth/withPermissions';
+import { MANAGE_PAGES_PERMISSION } from 'state/permissions/const';
 
 export const mapStateToProps = state => ({
   locale: getLocale(state),
@@ -44,4 +46,4 @@ export const mapDispatchToProps = dispatch => ({
 const PageTreeContainer = connect(mapStateToProps, mapDispatchToProps)(PageTreePage);
 
 
-export default PageTreeContainer;
+export default withPermissions(MANAGE_PAGES_PERMISSION)(PageTreeContainer);

--- a/src/ui/pages/settings/PageSettings.js
+++ b/src/ui/pages/settings/PageSettings.js
@@ -7,9 +7,11 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import BreadcrumbItem from 'ui/common/BreadcrumbItem';
 import PageSettingsFormContainer from 'ui/pages/common/PageSettingsFormContainer';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 
-const pageSettings = () => (
+export const PageSettingsPageBody = () => (
   <InternalPage className="PageSettings">
     <Grid fluid>
       <Row>
@@ -38,4 +40,4 @@ const pageSettings = () => (
 );
 
 
-export default pageSettings;
+export default withPermissions(ROLE_SUPERUSER)(PageSettingsPageBody);

--- a/src/ui/profile-types/add/AddProfileTypesPage.js
+++ b/src/ui/profile-types/add/AddProfileTypesPage.js
@@ -7,7 +7,8 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import AddFormContainer from 'ui/profile-types/add/AddFormContainer';
 import { ROUTE_PROFILE_TYPE_LIST } from 'app-init/router';
-
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 const AddProfileTypesPage = () => (
   <InternalPage className="AddProfileTypesPage">
@@ -40,4 +41,4 @@ const AddProfileTypesPage = () => (
   </InternalPage>
 );
 
-export default AddProfileTypesPage;
+export default withPermissions(ROLE_SUPERUSER)(AddProfileTypesPage);

--- a/src/ui/profile-types/attributes/AddProfileTypeAttributePage.js
+++ b/src/ui/profile-types/attributes/AddProfileTypeAttributePage.js
@@ -53,4 +53,6 @@ AddProfileTypeAttributePage.propTypes = {
   intl: intlShape.isRequired,
 };
 
-export default withPermissions(ROLE_SUPERUSER)(injectIntl(AddProfileTypeAttributePage));
+const AddProfileTypeAttributePageWithIntl = injectIntl(AddProfileTypeAttributePage);
+
+export default withPermissions(ROLE_SUPERUSER)(AddProfileTypeAttributePageWithIntl);

--- a/src/ui/profile-types/attributes/AddProfileTypeAttributePage.js
+++ b/src/ui/profile-types/attributes/AddProfileTypeAttributePage.js
@@ -7,6 +7,8 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import AddFormContainer from 'ui/profile-types/attributes/AddFormContainer';
 import { ROUTE_PROFILE_TYPE_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 const msgs = defineMessages({
   appAdd: {
@@ -51,4 +53,4 @@ AddProfileTypeAttributePage.propTypes = {
   intl: intlShape.isRequired,
 };
 
-export default injectIntl(AddProfileTypeAttributePage);
+export default withPermissions(ROLE_SUPERUSER)(injectIntl(AddProfileTypeAttributePage));

--- a/src/ui/profile-types/attributes/EditProfileTypeAttributePage.js
+++ b/src/ui/profile-types/attributes/EditProfileTypeAttributePage.js
@@ -7,6 +7,8 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import EditFormContainer from 'ui/profile-types/attributes/EditFormContainer';
 import { ROUTE_PROFILE_TYPE_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 const msgs = defineMessages({
   appEdit: {
@@ -52,4 +54,4 @@ EditProfileTypeAttributePage.propTypes = {
   intl: intlShape.isRequired,
 };
 
-export default injectIntl(EditProfileTypeAttributePage);
+export default withPermissions(ROLE_SUPERUSER)(injectIntl(EditProfileTypeAttributePage));

--- a/src/ui/profile-types/attributes/EditProfileTypeAttributePage.js
+++ b/src/ui/profile-types/attributes/EditProfileTypeAttributePage.js
@@ -54,4 +54,6 @@ EditProfileTypeAttributePage.propTypes = {
   intl: intlShape.isRequired,
 };
 
-export default withPermissions(ROLE_SUPERUSER)(injectIntl(EditProfileTypeAttributePage));
+const EditProfileTypeAttributePageWithIntl = injectIntl(EditProfileTypeAttributePage);
+
+export default withPermissions(ROLE_SUPERUSER)(EditProfileTypeAttributePageWithIntl);

--- a/src/ui/profile-types/edit/EditProfileTypesPage.js
+++ b/src/ui/profile-types/edit/EditProfileTypesPage.js
@@ -7,7 +7,8 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import EditFormContainer from 'ui/profile-types/edit/EditFormContainer';
 import { ROUTE_PROFILE_TYPE_LIST } from 'app-init/router';
-
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 const EditProfileTypesPage = () => (
   <InternalPage className="EditProfileTypesPage">
@@ -40,4 +41,4 @@ const EditProfileTypesPage = () => (
   </InternalPage>
 );
 
-export default EditProfileTypesPage;
+export default withPermissions(ROLE_SUPERUSER)(EditProfileTypesPage);

--- a/src/ui/profile-types/list/ListProfileTypePage.js
+++ b/src/ui/profile-types/list/ListProfileTypePage.js
@@ -8,8 +8,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import ProfileTypeListTableContainer from 'ui/profile-types/list/ProfileTypeListTableContainer';
 import { ROUTE_PROFILE_TYPE_ADD } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const ListProfileTypePage = () => (
+export const ListProfileTypePageBody = () => (
   <InternalPage className="ListProfileTypePage">
     <Grid fluid>
       <Row>
@@ -49,4 +51,4 @@ const ListProfileTypePage = () => (
   </InternalPage>
 );
 
-export default ListProfileTypePage;
+export default withPermissions(ROLE_SUPERUSER)(ListProfileTypePageBody);

--- a/src/ui/reload-configuration/ReloadConfigPage.js
+++ b/src/ui/reload-configuration/ReloadConfigPage.js
@@ -6,8 +6,10 @@ import BreadcrumbItem from 'ui/common/BreadcrumbItem';
 import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import ReloadConfigContainer from 'ui/reload-configuration/ReloadConfigContainer';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const ReloadConfigPage = () => (
+export const ReloadConfigPageBody = () => (
 
   <InternalPage className="ReloadConfPage">
     <Grid fluid>
@@ -37,4 +39,4 @@ const ReloadConfigPage = () => (
 );
 
 
-export default ReloadConfigPage;
+export default withPermissions(ROLE_SUPERUSER)(ReloadConfigPageBody);

--- a/src/ui/reload-configuration/ReloadConfirmPage.js
+++ b/src/ui/reload-configuration/ReloadConfirmPage.js
@@ -7,8 +7,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import ReloadConfirmContainer from 'ui/reload-configuration/ReloadConfirmContainer';
 import { ROUTE_RELOAD_CONFIG } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const ReloadConfirmPage = () => (
+export const ReloadConfirmPageBody = () => (
 
   <InternalPage className="ReloadConfirmPage">
     <Grid fluid>
@@ -41,4 +43,4 @@ const ReloadConfirmPage = () => (
 );
 
 
-export default ReloadConfirmPage;
+export default withPermissions(ROLE_SUPERUSER)(ReloadConfirmPageBody);

--- a/src/ui/roles/add/AddRolePage.js
+++ b/src/ui/roles/add/AddRolePage.js
@@ -7,8 +7,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import AddFormContainer from 'ui/roles/add/AddFormContainer';
 import { ROUTE_ROLE_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const AddRolePage = () => (
+export const AddRolePageBody = () => (
 
   <InternalPage className="AddRolePage">
     <Grid fluid>
@@ -41,4 +43,4 @@ const AddRolePage = () => (
 );
 
 
-export default AddRolePage;
+export default withPermissions(ROLE_SUPERUSER)(AddRolePageBody);

--- a/src/ui/roles/detail/DetailRolePage.js
+++ b/src/ui/roles/detail/DetailRolePage.js
@@ -7,8 +7,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import DetailRoleTableContainer from 'ui/roles/detail/DetailRoleTableContainer';
 import { ROUTE_ROLE_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const DetailRolePage = () => (
+export const DetailRolePageBody = () => (
   <InternalPage className="DetailRolePage">
     <Grid fluid>
       <Row>
@@ -43,4 +45,4 @@ const DetailRolePage = () => (
   </InternalPage>
 );
 
-export default DetailRolePage;
+export default withPermissions(ROLE_SUPERUSER)(DetailRolePageBody);

--- a/src/ui/roles/edit/EditRolePage.js
+++ b/src/ui/roles/edit/EditRolePage.js
@@ -7,8 +7,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import EditFormContainer from 'ui/roles/edit/EditFormContainer';
 import { ROUTE_ROLE_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const EditRolePage = () => (
+export const EditRolePageBody = () => (
 
   <InternalPage className="EditRolePage">
     <Grid fluid>
@@ -41,4 +43,4 @@ const EditRolePage = () => (
 );
 
 
-export default EditRolePage;
+export default withPermissions(ROLE_SUPERUSER)(EditRolePageBody);

--- a/src/ui/roles/list/ListRolePage.js
+++ b/src/ui/roles/list/ListRolePage.js
@@ -8,8 +8,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import RoleListTableContainer from 'ui/roles/list/RoleListTableContainer';
 import { ROUTE_ROLE_ADD } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const ListRolePage = () => (
+export const ListRolePageBody = () => (
   <InternalPage className="ListRolePage">
     <Grid fluid>
       <Row>
@@ -54,4 +56,4 @@ const ListRolePage = () => (
   </InternalPage>
 );
 
-export default ListRolePage;
+export default withPermissions(ROLE_SUPERUSER)(ListRolePageBody);

--- a/src/ui/roles/list/RoleListTableContainer.js
+++ b/src/ui/roles/list/RoleListTableContainer.js
@@ -5,7 +5,6 @@ import { getRolesList } from 'state/roles/selectors';
 import { getLoading } from 'state/loading/selectors';
 import { getCurrentPage, getTotalItems, getPageSize } from 'state/pagination/selectors';
 import RoleListTable from 'ui/roles/list/RoleListTable';
-import { toggleLoading } from 'state/loading/actions';
 import { setVisibleModal, setInfo } from 'state/modal/actions';
 import { MODAL_ID } from 'ui/roles/common/DeleteRoleModal';
 
@@ -21,7 +20,6 @@ export const mapStateToProps = state => (
 
 export const mapDispatchToProps = dispatch => ({
   onWillMount: (page) => {
-    dispatch(toggleLoading('roles'));
     dispatch(fetchRoles(page));
   },
   onClickDelete: (code) => {

--- a/src/ui/user-profile/edit/EditUserProfilePage.js
+++ b/src/ui/user-profile/edit/EditUserProfilePage.js
@@ -7,8 +7,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import EditUserProfileFormContainer from 'ui/user-profile/edit/EditUserProfileFormContainer';
 import { ROUTE_USER_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const EditUserProfilePage = () => (
+export const EditUserProfilePageBody = () => (
   <InternalPage className="EditUserProfilePage">
     <Grid fluid>
       <Row>
@@ -39,4 +41,4 @@ const EditUserProfilePage = () => (
   </InternalPage>
 );
 
-export default EditUserProfilePage;
+export default withPermissions(ROLE_SUPERUSER)(EditUserProfilePageBody);

--- a/src/ui/users/add/AddUserPage.js
+++ b/src/ui/users/add/AddUserPage.js
@@ -7,8 +7,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import AddFormContainer from 'ui/users/add/AddFormContainer';
 import { ROUTE_USER_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { CRUD_USERS_PERMISSION } from 'state/permissions/const';
 
-const AddUserPage = () => (
+export const AddUserPageBody = () => (
 
   <InternalPage className="AddUserPage">
     <Grid fluid>
@@ -41,4 +43,4 @@ const AddUserPage = () => (
 );
 
 
-export default AddUserPage;
+export default withPermissions(CRUD_USERS_PERMISSION)(AddUserPageBody);

--- a/src/ui/users/authority/UserAuthorityPageContainer.js
+++ b/src/ui/users/authority/UserAuthorityPageContainer.js
@@ -1,10 +1,15 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import UserAuthorityPage from 'ui/users/authority/UserAuthorityPage';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 export const mapStateToProps = (state, { match: { params } }) =>
   ({
     username: params.username,
   });
 
-export default withRouter(connect(mapStateToProps, null)(UserAuthorityPage));
+const UserAuthorityPageContainer =
+connect(mapStateToProps, null)(withPermissions(ROLE_SUPERUSER)(UserAuthorityPage));
+
+export default withRouter(UserAuthorityPageContainer);

--- a/src/ui/users/detail/DetailUserPage.js
+++ b/src/ui/users/detail/DetailUserPage.js
@@ -7,8 +7,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import { ROUTE_USER_LIST } from 'app-init/router';
 import DetailUserTableContainer from 'ui/users/detail/DetailUserTableContainer';
+import withPermissions from 'ui/auth/withPermissions';
+import { CRUD_USERS_PERMISSION } from 'state/permissions/const';
 
-const DetailUserPage = () => (
+export const DetailUserPageBody = () => (
   <InternalPage className="DetailUserPage">
     <Grid fluid>
       <Row>
@@ -38,4 +40,4 @@ const DetailUserPage = () => (
     </Grid>
   </InternalPage>
 );
-export default DetailUserPage;
+export default withPermissions(CRUD_USERS_PERMISSION)(DetailUserPageBody);

--- a/src/ui/users/edit/EditUserPage.js
+++ b/src/ui/users/edit/EditUserPage.js
@@ -7,8 +7,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import EditFormContainer from 'ui/users/edit/EditFormContainer';
 import { ROUTE_USER_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { CRUD_USERS_PERMISSION } from 'state/permissions/const';
 
-const EditUserPage = () => (
+export const EditUserPageBody = () => (
   <InternalPage className="EditUserPage">
     <Grid fluid>
       <Row>
@@ -39,4 +41,4 @@ const EditUserPage = () => (
   </InternalPage>
 );
 
-export default EditUserPage;
+export default withPermissions(CRUD_USERS_PERMISSION)(EditUserPageBody);

--- a/src/ui/users/list/UserListPage.js
+++ b/src/ui/users/list/UserListPage.js
@@ -9,8 +9,10 @@ import PageTitle from 'ui/internal-page/PageTitle';
 import UserListTableContainer from 'ui/users/list/UserListTableContainer';
 import UserSearchFormContainer from 'ui/users/list/UserSearchFormContainer';
 import { ROUTE_USER_ADD } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { VIEW_USERS_AND_PROFILES_PERMISSION } from 'state/permissions/const';
 
-const ListUserPage = () => (
+export const UserListPageBody = () => (
   <InternalPage className="UserListPage">
     <Grid fluid>
       <Row>
@@ -61,4 +63,4 @@ const ListUserPage = () => (
   </InternalPage>
 );
 
-export default ListUserPage;
+export default withPermissions(VIEW_USERS_AND_PROFILES_PERMISSION)(UserListPageBody);

--- a/src/ui/users/restrictions/UserRestrictionsPage.js
+++ b/src/ui/users/restrictions/UserRestrictionsPage.js
@@ -6,8 +6,10 @@ import BreadcrumbItem from 'ui/common/BreadcrumbItem';
 import InternalPage from 'ui/internal-page/InternalPage';
 import PageTitle from 'ui/internal-page/PageTitle';
 import RestrictionsFormContainer from 'ui/users/restrictions/RestrictionsFormContainer';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-const UserRestrictionsPage = () => (
+export const UserRestrictionsPageBody = () => (
   <InternalPage className="UserRestrictionsPage">
     <Grid fluid>
       <Row>
@@ -39,4 +41,4 @@ const UserRestrictionsPage = () => (
   </InternalPage>
 );
 
-export default UserRestrictionsPage;
+export default withPermissions(ROLE_SUPERUSER)(UserRestrictionsPageBody);

--- a/src/ui/widgets/add/AddWidgetPage.js
+++ b/src/ui/widgets/add/AddWidgetPage.js
@@ -8,9 +8,10 @@ import InternalPage from 'ui/internal-page/InternalPage';
 import WidgetFormContainer from 'ui/widgets/common/WidgetFormContainer';
 import ErrorsAlertContainer from 'ui/common/form/ErrorsAlertContainer';
 import { ROUTE_WIDGET_LIST } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
-
-const AddWidgetPage = () => (
+export const AddWidgetPageBody = () => (
   <InternalPage className="AddWidgetPage">
     <Grid fluid>
       <Row>
@@ -43,4 +44,4 @@ const AddWidgetPage = () => (
   </InternalPage>
 );
 
-export default AddWidgetPage;
+export default withPermissions(ROLE_SUPERUSER)(AddWidgetPageBody);

--- a/src/ui/widgets/config/WidgetConfigPageContainer.js
+++ b/src/ui/widgets/config/WidgetConfigPageContainer.js
@@ -7,7 +7,8 @@ import WidgetConfigPage from 'ui/widgets/config/WidgetConfigPage';
 import { getSelectedWidget } from 'state/widgets/selectors';
 import { makeGetWidgetConfigFrameName } from 'state/widget-config/selectors';
 import { updateConfiguredPageWidget, initWidgetConfigPage, initWidgetConfigPageWithConfigData } from 'state/widget-config/actions';
-
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 export const mapDispatchToProps = (dispatch, { match: { params } }) => ({
   onDidMount: ({ widgetConfig }) => {
@@ -50,4 +51,4 @@ export default withRouter(injectIntl(connect(
   {
     pure: false,
   },
-)(WidgetConfigPage)));
+)(withPermissions(ROLE_SUPERUSER)(WidgetConfigPage))));

--- a/src/ui/widgets/detail/DetailWidgetPageContainer.js
+++ b/src/ui/widgets/detail/DetailWidgetPageContainer.js
@@ -5,6 +5,8 @@ import { getWidgetInfo } from 'state/widgets/selectors';
 import DetailWidgetPage from 'ui/widgets/detail/DetailWidgetPage';
 import { getDefaultLanguage } from 'state/languages/selectors';
 import { fetchLanguages } from 'state/languages/actions';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 export const mapStateToProps = state => ({
   widgetInfo: getWidgetInfo(state),
@@ -18,4 +20,7 @@ export const mapDispatchToProps = (dispatch, { match: { params } }) => ({
   },
 });
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(DetailWidgetPage));
+export default withRouter(connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(withPermissions(ROLE_SUPERUSER)(DetailWidgetPage)));

--- a/src/ui/widgets/detail/DetailWidgetPageContainer.js
+++ b/src/ui/widgets/detail/DetailWidgetPageContainer.js
@@ -20,7 +20,9 @@ export const mapDispatchToProps = (dispatch, { match: { params } }) => ({
   },
 });
 
-export default withRouter(connect(
+const DetailWidgetPageContainer = withRouter(connect(
   mapStateToProps,
   mapDispatchToProps,
-)(withPermissions(ROLE_SUPERUSER)(DetailWidgetPage)));
+)(DetailWidgetPage));
+
+export default withPermissions(ROLE_SUPERUSER)(DetailWidgetPageContainer);

--- a/src/ui/widgets/edit/EditWidgetPageContainer.js
+++ b/src/ui/widgets/edit/EditWidgetPageContainer.js
@@ -4,6 +4,8 @@ import { connect } from 'react-redux';
 // import the Component to be connected
 import EditWidgetPage from 'ui/widgets/edit/EditWidgetPage';
 import { formValueSelector } from 'redux-form';
+import withPermissions from 'ui/auth/withPermissions';
+import { ROLE_SUPERUSER } from 'state/permissions/const';
 
 export const mapStateToProps = state => (
   {
@@ -14,4 +16,4 @@ export const mapStateToProps = state => (
 const EditWidgetPageContainer = connect(mapStateToProps, null)(EditWidgetPage);
 
 // export connected component (Container)
-export default EditWidgetPageContainer;
+export default withPermissions(ROLE_SUPERUSER)(EditWidgetPageContainer);

--- a/src/ui/widgets/list/ListWidgetPageContainer.js
+++ b/src/ui/widgets/list/ListWidgetPageContainer.js
@@ -9,6 +9,8 @@ import { MODAL_ID } from 'ui/widgets/list/DeleteWidgetModal';
 import { setVisibleModal, setInfo } from 'state/modal/actions';
 import { routeConverter } from '@entando/utils/dist/routeConverter';
 import { ROUTE_WIDGET_EDIT } from 'app-init/router';
+import withPermissions from 'ui/auth/withPermissions';
+import { MANAGE_PAGES_PERMISSION } from 'state/permissions/const';
 
 
 export const mapStateToProps = state => ({
@@ -33,4 +35,4 @@ export const mapDispatchToProps = (dispatch, { history }) => ({
 const ListWidgetPageContainer =
   withRouter(connect(mapStateToProps, mapDispatchToProps)(ListWidgetPage));
 
-export default ListWidgetPageContainer;
+export default withPermissions(MANAGE_PAGES_PERMISSION)(ListWidgetPageContainer);

--- a/test/state/permissions/reducer.test.js
+++ b/test/state/permissions/reducer.test.js
@@ -17,7 +17,7 @@ describe('state/permssions/reducer', () => {
       expect(state).toHaveProperty('list');
       expect(state).toHaveProperty('map');
       expect(state).toHaveProperty('loggedUser');
-      expect(state.loggedUser).toHaveLength(0);
+      expect(state.loggedUser).toBe(null);
     });
   });
 
@@ -49,7 +49,7 @@ describe('state/permssions/reducer', () => {
 
     it('after action CLEAR_LOGGED_USER_PERMISSIONS', () => {
       state = reducer(state, clearLoggedUserPermissions());
-      expect(state.loggedUser).toHaveLength(0);
+      expect(state.loggedUser).toBe(null);
     });
   });
 });

--- a/test/state/roles/actions.test.js
+++ b/test/state/roles/actions.test.js
@@ -69,17 +69,18 @@ describe('state/roles/actions', () => {
     it('fetchRoles calls setRoles and setPage actions', (done) => {
       store.dispatch(fetchRoles()).then(() => {
         const actions = store.getActions();
-        expect(actions).toHaveLength(3);
-        expect(actions[0]).toHaveProperty('type', SET_ROLES);
-        expect(actions[1]).toHaveProperty('type', TOGGLE_LOADING);
+        expect(actions).toHaveLength(4);
+        expect(actions[0]).toHaveProperty('type', TOGGLE_LOADING);
+        expect(actions[1]).toHaveProperty('type', SET_ROLES);
         expect(actions[2]).toHaveProperty('type', SET_PAGE);
+        expect(actions[3]).toHaveProperty('type', TOGGLE_LOADING);
         done();
       }).catch(done.fail);
     });
 
     it('role is defined and properly valued', (done) => {
       store.dispatch(fetchRoles()).then(() => {
-        const actionPayload = store.getActions()[0].payload;
+        const actionPayload = store.getActions()[1].payload;
         expect(actionPayload.roles).toHaveLength(10);
         const role = actionPayload.roles[0];
         expect(role).toHaveProperty('code', 'contentEditing');
@@ -93,10 +94,11 @@ describe('state/roles/actions', () => {
       store.dispatch(fetchRoles()).then(() => {
         expect(getRoles).toHaveBeenCalled();
         const actions = store.getActions();
-        expect(actions).toHaveLength(3);
-        expect(actions[0]).toHaveProperty('type', ADD_ERRORS);
-        expect(actions[1]).toHaveProperty('type', ADD_TOAST);
-        expect(actions[2]).toHaveProperty('type', TOGGLE_LOADING);
+        expect(actions).toHaveLength(4);
+        expect(actions[0]).toHaveProperty('type', TOGGLE_LOADING);
+        expect(actions[1]).toHaveProperty('type', ADD_ERRORS);
+        expect(actions[2]).toHaveProperty('type', ADD_TOAST);
+        expect(actions[3]).toHaveProperty('type', TOGGLE_LOADING);
         done();
       }).catch(done.fail);
     });

--- a/test/ui/categories/add/AddCategoryPage.test.js
+++ b/test/ui/categories/add/AddCategoryPage.test.js
@@ -2,12 +2,12 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import AddCategoryPage from 'ui/categories/add/AddCategoryPage';
+import { AddCategoryPageBody } from 'ui/categories/add/AddCategoryPage';
 
 describe('AddCategoryPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<AddCategoryPage />);
+    component = shallow(<AddCategoryPageBody />);
   });
   it('renders without crashing', () => {
     expect(component).toExist();

--- a/test/ui/categories/detail/DetailCategoryPage.test.js
+++ b/test/ui/categories/detail/DetailCategoryPage.test.js
@@ -3,12 +3,12 @@ import React from 'react';
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
 import InternalPage from 'ui/internal-page/InternalPage';
-import DetailCategoryPage from 'ui/categories/detail/DetailCategoryPage';
+import { DetailCategoryPageBody } from 'ui/categories/detail/DetailCategoryPage';
 
 describe('DetailCategoryPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<DetailCategoryPage />);
+    component = shallow(<DetailCategoryPageBody />);
   });
   it('renders without crashing', () => {
     expect(component).toExist();

--- a/test/ui/categories/edit/EditCategoryPage.test.js
+++ b/test/ui/categories/edit/EditCategoryPage.test.js
@@ -1,13 +1,13 @@
 import React from 'react';
 
 import 'test/enzyme-init';
-import EditCategoryPage from 'ui/categories/edit/EditCategoryPage';
+import { EditCategoryPageBody } from 'ui/categories/edit/EditCategoryPage';
 import { shallowWithIntl } from 'test/testUtils';
 
 describe('EditCategoryPage', () => {
   let component;
   beforeEach(() => {
-    component = shallowWithIntl(<EditCategoryPage />);
+    component = shallowWithIntl(<EditCategoryPageBody />);
   });
   it('renders without crashing', () => {
     expect(component).toExist();

--- a/test/ui/categories/list/ListCategoryPage.test.js
+++ b/test/ui/categories/list/ListCategoryPage.test.js
@@ -3,12 +3,12 @@ import 'test/enzyme-init';
 
 import { shallow } from 'enzyme';
 
-import ListCategoryPage from 'ui/categories/list/ListCategoryPage';
+import { ListCategoryPageBody } from 'ui/categories/list/ListCategoryPage';
 
 describe('ListCategoryPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<ListCategoryPage />);
+    component = shallow(<ListCategoryPageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/component-repository/components/list/ComponentListPage.test.js
+++ b/test/ui/component-repository/components/list/ComponentListPage.test.js
@@ -2,12 +2,12 @@ import React from 'react';
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
 
-import ComponentListPage from 'ui/component-repository/components/list/ComponentListPage';
+import { ComponentListPageBody } from 'ui/component-repository/components/list/ComponentListPage';
 
 describe('ComponentListPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<ComponentListPage />);
+    component = shallow(<ComponentListPageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/data-models/add/AddDataModelPage.test.js
+++ b/test/ui/data-models/add/AddDataModelPage.test.js
@@ -2,12 +2,12 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import AddDataModelPage from 'ui/data-models/add/AddDataModelPage';
+import { AddDataModelPageBody } from 'ui/data-models/add/AddDataModelPage';
 
 describe('AddDataModelPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<AddDataModelPage />);
+    component = shallow(<AddDataModelPageBody />);
   });
   it('renders without crashing', () => {
     expect(component.exists()).toEqual(true);

--- a/test/ui/data-models/edit/EditDataModelPage.test.js
+++ b/test/ui/data-models/edit/EditDataModelPage.test.js
@@ -1,13 +1,13 @@
 import React from 'react';
 
 import 'test/enzyme-init';
-import EditDataModelPage from 'ui/data-models/edit/EditDataModelPage';
+import { EditDataModelPageBody } from 'ui/data-models/edit/EditDataModelPage';
 import { shallowWithIntl } from 'test/testUtils';
 
 describe('EditDataModelPage', () => {
   let component;
   beforeEach(() => {
-    component = shallowWithIntl(<EditDataModelPage />);
+    component = shallowWithIntl(<EditDataModelPageBody />);
   });
   it('renders without crashing', () => {
     expect(component.exists()).toBe(true);

--- a/test/ui/data-types/list/ListDataTypePage.test.js
+++ b/test/ui/data-types/list/ListDataTypePage.test.js
@@ -3,12 +3,12 @@ import 'test/enzyme-init';
 
 import { shallow } from 'enzyme';
 
-import ListDataTypePage from 'ui/data-types/list/ListDataTypePage';
+import { ListDataTypePageBody } from 'ui/data-types/list/ListDataTypePage';
 
 describe('ListDataTypePage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<ListDataTypePage />);
+    component = shallow(<ListDataTypePageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/database/list/ListDatabasePage.test.js
+++ b/test/ui/database/list/ListDatabasePage.test.js
@@ -2,12 +2,12 @@ import React from 'react';
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
 
-import DatabaseListPage from 'ui/database/list/ListDatabasePage';
+import { DatabaseListPageBody } from 'ui/database/list/ListDatabasePage';
 
 describe('DatabaseListPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<DatabaseListPage />);
+    component = shallow(<DatabaseListPageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/file-browser/add/CreateFolderPage.test.js
+++ b/test/ui/file-browser/add/CreateFolderPage.test.js
@@ -2,12 +2,12 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import CreateFolderPage from 'ui/file-browser/add/CreateFolderPage';
+import { CreateFolderPageBody } from 'ui/file-browser/add/CreateFolderPage';
 
 describe('CreateFolderPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<CreateFolderPage />);
+    component = shallow(<CreateFolderPageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/file-browser/edit/EditTextFilePage.test.js
+++ b/test/ui/file-browser/edit/EditTextFilePage.test.js
@@ -2,12 +2,12 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import EditTextFilePage from 'ui/file-browser/edit/EditTextFilePage';
+import { EditTextFilePageBody } from 'ui/file-browser/edit/EditTextFilePage';
 
 describe('EditTextFilePage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<EditTextFilePage />);
+    component = shallow(<EditTextFilePageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/file-browser/list/ListFilesPage.test.js
+++ b/test/ui/file-browser/list/ListFilesPage.test.js
@@ -2,12 +2,12 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import ListFilesPage from 'ui/file-browser/list/ListFilesPage';
+import { ListFilesPageBody } from 'ui/file-browser/list/ListFilesPage';
 
 describe('ListFilesPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<ListFilesPage />);
+    component = shallow(<ListFilesPageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/file-browser/upload/UploadFileBrowserPage.test.js
+++ b/test/ui/file-browser/upload/UploadFileBrowserPage.test.js
@@ -2,13 +2,13 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import UploadFileBrowserPage from 'ui/file-browser/upload/UploadFileBrowserPage';
+import { UploadFileBrowserPageBody } from 'ui/file-browser/upload/UploadFileBrowserPage';
 import UploadFileBrowserFormContainer from 'ui/file-browser/upload/UploadFileBrowserFormContainer';
 
 describe('UploadFileBrowserPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<UploadFileBrowserPage location={{ pathname: '' }} />);
+    component = shallow(<UploadFileBrowserPageBody location={{ pathname: '' }} />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/fragments/add/AddFragmentPage.test.js
+++ b/test/ui/fragments/add/AddFragmentPage.test.js
@@ -1,13 +1,13 @@
 import React from 'react';
 
 import 'test/enzyme-init';
-import AddFragmentPage from 'ui/fragments/add/AddFragmentPage';
+import { AddFragmentPageBody } from 'ui/fragments/add/AddFragmentPage';
 import { shallowWithIntl } from 'test/testUtils';
 
 describe('AddFragmentPage', () => {
   let component;
   beforeEach(() => {
-    component = shallowWithIntl(<AddFragmentPage />);
+    component = shallowWithIntl(<AddFragmentPageBody />);
   });
   it('renders without crashing', () => {
     expect(component.exists()).toEqual(true);

--- a/test/ui/fragments/list/ListFragmentPage.test.js
+++ b/test/ui/fragments/list/ListFragmentPage.test.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import 'test/enzyme-init';
 
-import ListFragmentPage from 'ui/fragments/list/ListFragmentPage';
+import { ListFragmentPageBody } from 'ui/fragments/list/ListFragmentPage';
 import { shallowWithIntl } from 'test/testUtils';
 
 describe('ListFragmentPage', () => {
   let component;
   beforeEach(() => {
-    component = shallowWithIntl(<ListFragmentPage />);
+    component = shallowWithIntl(<ListFragmentPageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/groups/add/AddGroupPage.test.js
+++ b/test/ui/groups/add/AddGroupPage.test.js
@@ -2,12 +2,12 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import AddGroupPage from 'ui/groups/add/AddGroupPage';
+import { AddGroupPageBody } from 'ui/groups/add/AddGroupPage';
 
 describe('AddGroupPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<AddGroupPage />);
+    component = shallow(<AddGroupPageBody />);
   });
   it('renders without crashing', () => {
     expect(component.exists()).toEqual(true);

--- a/test/ui/groups/detail/DetailGroupPage.test.js
+++ b/test/ui/groups/detail/DetailGroupPage.test.js
@@ -3,12 +3,12 @@ import 'test/enzyme-init';
 
 import { shallow } from 'enzyme';
 
-import DetailGroupPage from 'ui/groups/detail/DetailGroupPage';
+import { DetailGroupPageBody } from 'ui/groups/detail/DetailGroupPage';
 
 describe('DetailGroupPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<DetailGroupPage />);
+    component = shallow(<DetailGroupPageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/groups/edit/EditGroupPage.test.js
+++ b/test/ui/groups/edit/EditGroupPage.test.js
@@ -2,12 +2,12 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import EditGroupPage from 'ui/groups/edit/EditGroupPage';
+import { EditGroupPageBody } from 'ui/groups/edit/EditGroupPage';
 
 describe('EditGroupPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<EditGroupPage />);
+    component = shallow(<EditGroupPageBody />);
   });
   it('renders without crashing', () => {
     expect(component.exists()).toEqual(true);

--- a/test/ui/groups/list/ListGroupPage.test.js
+++ b/test/ui/groups/list/ListGroupPage.test.js
@@ -3,12 +3,12 @@ import 'test/enzyme-init';
 
 import { shallow } from 'enzyme';
 
-import ListGroupPage from 'ui/groups/list/ListGroupPage';
+import { ListGroupPageBody } from 'ui/groups/list/ListGroupPage';
 
 describe('ListGroupPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<ListGroupPage />);
+    component = shallow(<ListGroupPageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/labels/add/AddLabelsPage.test.js
+++ b/test/ui/labels/add/AddLabelsPage.test.js
@@ -3,12 +3,12 @@ import React from 'react';
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
 import InternalPage from 'ui/internal-page/InternalPage';
-import AddLabelPage from 'ui/labels/add/AddLabelPage';
+import { AddLabelPageBody } from 'ui/labels/add/AddLabelPage';
 
 describe('AddLabelPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<AddLabelPage />);
+    component = shallow(<AddLabelPageBody />);
   });
   it('renders without crashing', () => {
     expect(component).toExist();

--- a/test/ui/labels/edit/EditLabelPage.test.js
+++ b/test/ui/labels/edit/EditLabelPage.test.js
@@ -3,12 +3,12 @@ import React from 'react';
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
 import InternalPage from 'ui/internal-page/InternalPage';
-import EditLabelPage from 'ui/labels/edit/EditLabelPage';
+import { EditLabelPageBody } from 'ui/labels/edit/EditLabelPage';
 
 describe('EditLabelPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<EditLabelPage />);
+    component = shallow(<EditLabelPageBody />);
   });
   it('renders without crashing', () => {
     expect(component).toExist();

--- a/test/ui/page-templates/add/PageTemplateAddPage.test.js
+++ b/test/ui/page-templates/add/PageTemplateAddPage.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import PageTemplateAddPage from 'ui/page-templates/add/PageTemplateAddPage';
+import { PageTemplateAddPageBody } from 'ui/page-templates/add/PageTemplateAddPage';
 
 
 describe('PageTemplateAddPage', () => {
@@ -10,7 +10,7 @@ describe('PageTemplateAddPage', () => {
 
   let component;
   beforeEach(() => {
-    component = shallow(<PageTemplateAddPage />);
+    component = shallow(<PageTemplateAddPageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/page-templates/detail/PageTemplateDetailPage.test.js
+++ b/test/ui/page-templates/detail/PageTemplateDetailPage.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import PageTemplateDetailPage from 'ui/page-templates/detail/PageTemplateDetailPage';
+import { PageTemplateDetailPageBody } from 'ui/page-templates/detail/PageTemplateDetailPage';
 
 const PAGE_TEMPLATE_CODE = 'page_model_code';
 
@@ -11,7 +11,7 @@ describe('PageTemplateDetailPage', () => {
 
   let component;
   beforeEach(() => {
-    component = shallow(<PageTemplateDetailPage pageTemplateCode={PAGE_TEMPLATE_CODE} />);
+    component = shallow(<PageTemplateDetailPageBody pageTemplateCode={PAGE_TEMPLATE_CODE} />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/page-templates/edit/PageTemplateEditPage.test.js
+++ b/test/ui/page-templates/edit/PageTemplateEditPage.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import PageTemplateEditPage from 'ui/page-templates/edit/PageTemplateEditPage';
+import { PageTemplateEditPageBody } from 'ui/page-templates/edit/PageTemplateEditPage';
 
 
 describe('PageTemplateEditPage', () => {
@@ -10,7 +10,7 @@ describe('PageTemplateEditPage', () => {
 
   let component;
   beforeEach(() => {
-    component = shallow(<PageTemplateEditPage />);
+    component = shallow(<PageTemplateEditPageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/page-templates/list/PageTemplateListPage.test.js
+++ b/test/ui/page-templates/list/PageTemplateListPage.test.js
@@ -2,12 +2,12 @@ import React from 'react';
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
 
-import PageTemplateListPage from 'ui/page-templates/list/PageTemplateListPage';
+import { PageTemplateListPageBody } from 'ui/page-templates/list/PageTemplateListPage';
 
 describe('PageTemplateListPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<PageTemplateListPage />);
+    component = shallow(<PageTemplateListPageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/pages/clone/PagesClonePage.test.js
+++ b/test/ui/pages/clone/PagesClonePage.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import 'test/enzyme-init';
-import PagesClonePage from 'ui/pages/clone/PagesClonePage';
+import { PagesClonePageBody } from 'ui/pages/clone/PagesClonePage';
 import { shallowWithIntl } from 'test/testUtils';
 
 
@@ -10,7 +10,7 @@ describe('PagesClonePage', () => {
 
   let component;
   beforeEach(() => {
-    component = shallowWithIntl(<PagesClonePage />);
+    component = shallowWithIntl(<PagesClonePageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/pages/edit/PagesEditPage.test.js
+++ b/test/ui/pages/edit/PagesEditPage.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import PagesEditPage from 'ui/pages/edit/PagesEditPage';
+import { PagesEditPageBody } from 'ui/pages/edit/PagesEditPage';
 
 
 describe('PagesEditPage', () => {
@@ -10,7 +10,7 @@ describe('PagesEditPage', () => {
 
   let component;
   beforeEach(() => {
-    component = shallow(<PagesEditPage />);
+    component = shallow(<PagesEditPageBody />);
   });
 
   it('renders without crashing', () => {
@@ -27,7 +27,7 @@ describe('PagesEditPage', () => {
 
   it('will call onWillMount on componentWillMount', () => {
     const onWillMount = jest.fn();
-    shallow(<PagesEditPage onWillMount={onWillMount} />);
+    shallow(<PagesEditPageBody onWillMount={onWillMount} />);
     expect(onWillMount).toHaveBeenCalled();
   });
 });

--- a/test/ui/pages/settings/PageSettings.test.js
+++ b/test/ui/pages/settings/PageSettings.test.js
@@ -2,12 +2,12 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import PageSettingsPage from 'ui/pages/settings/PageSettings';
+import { PageSettingsPageBody } from 'ui/pages/settings/PageSettings';
 
 describe('WidgetEditPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<PageSettingsPage />);
+    component = shallow(<PageSettingsPageBody />);
   });
   it('renders without crashing', () => {
     expect(component.exists()).toEqual(true);

--- a/test/ui/profile-types/list/ListDataTypePage.test.js
+++ b/test/ui/profile-types/list/ListDataTypePage.test.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import 'test/enzyme-init';
 
-import ListProfileTypePage from 'ui/profile-types/list/ListProfileTypePage';
+import { ListProfileTypePageBody } from 'ui/profile-types/list/ListProfileTypePage';
 import { shallowWithIntl } from 'test/testUtils';
 
 describe('ListProfileTypePage', () => {
   let component;
   beforeEach(() => {
-    component = shallowWithIntl(<ListProfileTypePage />);
+    component = shallowWithIntl(<ListProfileTypePageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/reload-configuration/ReloadConfigPage.test.js
+++ b/test/ui/reload-configuration/ReloadConfigPage.test.js
@@ -2,13 +2,13 @@ import React from 'react';
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
 import InternalPage from 'ui/internal-page/InternalPage';
-import ReloadConfigPage from 'ui/reload-configuration/ReloadConfigPage';
+import { ReloadConfigPageBody } from 'ui/reload-configuration/ReloadConfigPage';
 
 
 describe('ReloadConfigPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<ReloadConfigPage />);
+    component = shallow(<ReloadConfigPageBody />);
   });
   it('renders without crashing', () => {
     expect(component).toExist();

--- a/test/ui/reload-configuration/ReloadConfirmPage.test.js
+++ b/test/ui/reload-configuration/ReloadConfirmPage.test.js
@@ -2,13 +2,13 @@ import React from 'react';
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
 import InternalPage from 'ui/internal-page/InternalPage';
-import ReloadConfirmPage from 'ui/reload-configuration/ReloadConfirmPage';
+import { ReloadConfirmPageBody } from 'ui/reload-configuration/ReloadConfirmPage';
 
 
 describe('ReloadConfirmPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<ReloadConfirmPage />);
+    component = shallow(<ReloadConfirmPageBody />);
   });
   it('renders without crashing', () => {
     expect(component).toExist();

--- a/test/ui/roles/add/AddRolePage.test.js
+++ b/test/ui/roles/add/AddRolePage.test.js
@@ -2,12 +2,12 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import AddRolePage from 'ui/roles/add/AddRolePage';
+import { AddRolePageBody } from 'ui/roles/add/AddRolePage';
 
 describe('AddRolePage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<AddRolePage />);
+    component = shallow(<AddRolePageBody />);
   });
   it('renders without crashing', () => {
     expect(component.exists()).toEqual(true);

--- a/test/ui/roles/detail/DetailRolePage.test.js
+++ b/test/ui/roles/detail/DetailRolePage.test.js
@@ -2,12 +2,12 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import DetailRolePage from 'ui/roles/detail/DetailRolePage';
+import { DetailRolePageBody } from 'ui/roles/detail/DetailRolePage';
 
 describe('DetailRolePage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<DetailRolePage />);
+    component = shallow(<DetailRolePageBody />);
   });
   it('renders without crashing', () => {
     expect(component.exists()).toBe(true);

--- a/test/ui/roles/edit/EditRolePage.test.js
+++ b/test/ui/roles/edit/EditRolePage.test.js
@@ -2,12 +2,12 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import EditRolePage from 'ui/roles/edit/EditRolePage';
+import { EditRolePageBody } from 'ui/roles/edit/EditRolePage';
 
 describe('EditRolePage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<EditRolePage />);
+    component = shallow(<EditRolePageBody />);
   });
   it('renders without crashing', () => {
     expect(component.exists()).toEqual(true);

--- a/test/ui/roles/list/ListRolePage.test.js
+++ b/test/ui/roles/list/ListRolePage.test.js
@@ -3,12 +3,12 @@ import 'test/enzyme-init';
 
 import { shallow } from 'enzyme';
 
-import ListRolePage from 'ui/roles/list/ListRolePage';
+import { ListRolePageBody } from 'ui/roles/list/ListRolePage';
 
 describe('ListRolePage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<ListRolePage />);
+    component = shallow(<ListRolePageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/roles/list/RoleListTableContainer.test.js
+++ b/test/ui/roles/list/RoleListTableContainer.test.js
@@ -1,7 +1,6 @@
 import 'test/enzyme-init';
 import { getRolesList } from 'state/roles/selectors';
 import { getLoading } from 'state/loading/selectors';
-import { toggleLoading } from 'state/loading/actions';
 import { setVisibleModal, setInfo } from 'state/modal/actions';
 import { mapStateToProps, mapDispatchToProps } from 'ui/roles/list/RoleListTableContainer';
 import { LIST_ROLES_OK, ROLES_NORMALIZED } from 'test/mocks/roles';
@@ -53,7 +52,6 @@ describe('RoleListTableContainer', () => {
     it('should dispatch an action if onWillMount is called', () => {
       props.onWillMount({});
       expect(dispatchMock).toHaveBeenCalled();
-      expect(toggleLoading).toHaveBeenCalledWith('roles');
     });
 
     it('should dispatch an action if onClickDelete is called', () => {

--- a/test/ui/user-profile/edit/EditUserProfilePage.test.js
+++ b/test/ui/user-profile/edit/EditUserProfilePage.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import EditUserProfilePage from 'ui/user-profile/edit/EditUserProfilePage';
+import { EditUserProfilePageBody } from 'ui/user-profile/edit/EditUserProfilePage';
 
 
 describe('EditUserProfilePage', () => {
@@ -10,7 +10,7 @@ describe('EditUserProfilePage', () => {
 
   let component;
   beforeEach(() => {
-    component = shallow(<EditUserProfilePage />);
+    component = shallow(<EditUserProfilePageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/users/add/AddUserPage.test.js
+++ b/test/ui/users/add/AddUserPage.test.js
@@ -2,12 +2,12 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import AddUserPage from 'ui/users/add/AddUserPage';
+import { AddUserPageBody } from 'ui/users/add/AddUserPage';
 
 describe('AddUserPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<AddUserPage />);
+    component = shallow(<AddUserPageBody />);
   });
   it('renders without crashing', () => {
     expect(component.exists()).toEqual(true);

--- a/test/ui/users/detail/DetailUserPage.test.js
+++ b/test/ui/users/detail/DetailUserPage.test.js
@@ -2,12 +2,12 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import DetailUserPage from 'ui/users/detail/DetailUserPage';
+import { DetailUserPageBody } from 'ui/users/detail/DetailUserPage';
 
 describe('AddUserPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<DetailUserPage />);
+    component = shallow(<DetailUserPageBody />);
   });
   it('renders without crashing', () => {
     expect(component.exists()).toEqual(true);

--- a/test/ui/users/edit/EditUserPage.test.js
+++ b/test/ui/users/edit/EditUserPage.test.js
@@ -2,13 +2,13 @@ import React from 'react';
 
 import 'test/enzyme-init';
 
-import EditUserPage from 'ui/users/edit/EditUserPage';
+import { EditUserPageBody } from 'ui/users/edit/EditUserPage';
 import { shallowWithIntl } from 'test/testUtils';
 
 describe('EditUserPage', () => {
   let component;
   beforeEach(() => {
-    component = shallowWithIntl(<EditUserPage />);
+    component = shallowWithIntl(<EditUserPageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/users/list/ListDataTypePage.test.js
+++ b/test/ui/users/list/ListDataTypePage.test.js
@@ -3,12 +3,12 @@ import 'test/enzyme-init';
 
 import { shallow } from 'enzyme';
 
-import UserListPage from 'ui/users/list/UserListPage';
+import { UserListPageBody } from 'ui/users/list/UserListPage';
 
 describe('UserListPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<UserListPage />);
+    component = shallow(<UserListPageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/users/restrictions/UserRestrictionsPage.test.js
+++ b/test/ui/users/restrictions/UserRestrictionsPage.test.js
@@ -3,13 +3,13 @@ import 'test/enzyme-init';
 
 import { shallow } from 'enzyme';
 
-import UserRestrictionsPage from 'ui/users/restrictions/UserRestrictionsPage';
+import { UserRestrictionsPageBody } from 'ui/users/restrictions/UserRestrictionsPage';
 import RestrictionsFormContainer from 'ui/users/restrictions/RestrictionsFormContainer';
 
 describe('UserRestrictionsPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<UserRestrictionsPage />);
+    component = shallow(<UserRestrictionsPageBody />);
   });
 
   it('renders without crashing', () => {

--- a/test/ui/widgets/add/AddWidgetPage.test.js
+++ b/test/ui/widgets/add/AddWidgetPage.test.js
@@ -2,12 +2,12 @@ import React from 'react';
 
 import 'test/enzyme-init';
 import { shallow } from 'enzyme';
-import AddWidgetPage from 'ui/widgets/add/AddWidgetPage';
+import { AddWidgetPageBody } from 'ui/widgets/add/AddWidgetPage';
 
 describe('AddWidgetPage', () => {
   let component;
   beforeEach(() => {
-    component = shallow(<AddWidgetPage />);
+    component = shallow(<AddWidgetPageBody />);
   });
   it('renders without crashing', () => {
     expect(component.exists()).toEqual(true);


### PR DESCRIPTION
- `loggedUser` property default value has been changed from empty array to `null`, because its necessary to know when permissions are not yet fetched to show spinner. (previous approach of having `toggleLoading` did not work, because for a second or less, 403 page appears, because default value for loading is `false` and then becomes `true`, that's why).