### PR TITLE
ENG-653 upgrade react testing library to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
       "^(?!.*\\.(js|jsx|mjs|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
     },
     "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$"
+      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
     ],
     "moduleNameMapper": {
       "^react-native$": "react-native-web",
@@ -170,8 +170,8 @@
     "extends": "react-app"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^5.0.2",
-    "@testing-library/react": "^9.4.0",
+    "@testing-library/jest-dom": "^5.9.0",
+    "@testing-library/react": "^10.2.0",
     "commander": "^3.0.2",
     "duplicate-package-checker-webpack-plugin": "^3.0.0",
     "eslint-plugin-react-hooks": "^2.3.0",


### PR DESCRIPTION
- Had to remove "mjs" extension from ignored files list from node_modules, as new RTL is using "mjs" files, so if we dont make babel transform those files RTL importing fails