### PR TITLE
ENG-722 implement clone widget with ConfigSimpleParam

### DIFF
--- a/src/app-init/router.js
+++ b/src/app-init/router.js
@@ -14,6 +14,7 @@ export const ROUTE_PAGE_CLONE = '/page/clone';
 export const ROUTE_PAGE_DETAIL = '/page/detail/:pageCode';
 export const ROUTE_PAGE_SETTINGS = '/page/settings';
 export const ROUTE_PAGE_CONFIG = '/page/configuration/:pageCode';
+export const ROUTE_CLONE_WIDGET = '/page/:pageCode/clone/:frameId/widget/:parentCode/:widgetAction';
 // page template
 export const ROUTE_PAGE_TEMPLATE_LIST = '/page-template';
 export const ROUTE_PAGE_TEMPLATE_ADD = '/page-template/add';

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -821,5 +821,9 @@ export default {
     'reference.status.title': 'Reference status',
     'user.table.profileType': 'Profile Type',
     'app.deleteRoleImpossible': 'Role cannot be deleted until it is removed from all the following users',
+    'app.saveAs': 'Save As',
+    'menu.widgetClone': 'Clone widget',
+    'widget.page.clone.pageTitle': 'Clone widget',
+    'app.saveAndReplace': 'Save and Replace',
   },
 };

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -821,5 +821,9 @@ export default {
     'reference.status.title': 'Stato di riferimento',
     'user.table.profileType': 'Tipo di profilo',
     'app.deleteRoleImpossible': 'Il ruolo non può essere eliminato finché non viene rimosso da tutti i seguenti utenti',
+    'app.saveAs': 'Salva come',
+    'menu.widgetClone': 'Clona widget',
+    'widget.page.clone.pageTitle': 'Clona widget',
+    'app.saveAndReplace': 'Salva e sostituisci',
   },
 };

--- a/src/locales/pt.js
+++ b/src/locales/pt.js
@@ -788,5 +788,9 @@ export default {
     'reference.status.title': 'Status de referência',
     'user.table.profileType': 'Tipo de Perfil',
     'app.deleteRoleImpossible': 'A função não pode ser excluída até que seja removida de todos os seguintes usuários',
+    'app.saveAs': 'Salvar como',
+    'menu.widgetClone': 'Clone widget',
+    'widget.page.clone.pageTitle': 'Clone widget',
+    'app.saveAndReplace': 'Salvar e substituir',
   },
 };

--- a/src/state/page-config/selectors.js
+++ b/src/state/page-config/selectors.js
@@ -77,6 +77,7 @@ export const makeGetPageConfigCellMap = params => createSelector(
             relatedCell.widgetCode = widget.code;
             relatedCell.widgetTitle = widget.titles[locale] || widget.name;
             relatedCell.widgetHasConfig = widget.hasConfig;
+            relatedCell.widgetAction = widget.action;
           }
         }
         if (draftItem && publishedConfig) {

--- a/src/state/widgets/actions.js
+++ b/src/state/widgets/actions.js
@@ -98,7 +98,7 @@ export const getSingleWidgetInfo = widgetCode => dispatch => (
   )).catch(() => {})
 );
 
-export const initNewUserWidget = widgetCode => (dispatch) => {
+export const initNewUserWidget = (widgetCode, isCloning = false) => (dispatch) => {
   toggleLoading('fetchWidget');
   dispatch(getSingleWidgetInfo(widgetCode)).then(({ ok, json }) => {
     if (ok) {
@@ -108,10 +108,12 @@ export const initNewUserWidget = widgetCode => (dispatch) => {
           [curr.code]: '',
         }), {});
       dispatch(setSelectedParentWidget(json.payload));
-      dispatch(initialize('widget', {
-        parentType: json.payload.code,
-        config,
-      }));
+      if (!isCloning) {
+        dispatch(initialize('widget', {
+          parentType: json.payload.code,
+          config,
+        }));
+      }
     } else {
       dispatch(removeParentWidget());
     }

--- a/src/ui/app/App.js
+++ b/src/ui/app/App.js
@@ -91,6 +91,7 @@ import {
   ROUTE_PLUGINS,
   ROUTE_ABOUT,
   ROUTE_LICENSE,
+  ROUTE_CLONE_WIDGET,
 } from 'app-init/router';
 
 import LoginFormContainer from 'ui/login/LoginFormContainer';
@@ -176,6 +177,7 @@ import CreateTextFilePage from 'ui/file-browser/add/CreateTextFilePage';
 import EditTextFilePage from 'ui/file-browser/edit/EditTextFilePage';
 import PluginsPageContainer from 'ui/plugins/PluginsPageContainer';
 import PageNotFoundContainer from 'ui/app/PageNotFoundContainer';
+import CloneWidgetPage from 'ui/widgets/clone/CloneWidgetPage';
 
 import InternalPage from 'ui/internal-page/InternalPage';
 import entandoApps from 'entando-apps';
@@ -231,6 +233,7 @@ const getRouteComponent = () => {
       <Route path={ROUTE_WIDGET_NEW_USERWIDGET} component={NewUserWidgetPage} />
       <Route path={ROUTE_WIDGET_DETAIL} component={DetailWidgetPageContainer} />
       <Route path={ROUTE_WIDGET_CONFIG} component={WidgetConfigPageContainer} />
+      <Route path={ROUTE_CLONE_WIDGET} component={CloneWidgetPage} />
       {/* fragments */}
       <Route exact path={ROUTE_FRAGMENT_LIST} component={ListFragmentPage} />
       <Route path={ROUTE_FRAGMENT_ADD} component={AddFragmentPage} />

--- a/src/ui/pages/config/DraggableWidgetFrame.js
+++ b/src/ui/pages/config/DraggableWidgetFrame.js
@@ -1,14 +1,18 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
+import { routeConverter } from '@entando/utils';
 
 import frameDragSource from 'ui/pages/config/frameDragSource';
 import frameDropTarget from 'ui/pages/config/frameDropTarget';
 import WidgetFrame from 'ui/pages/config/WidgetFrame';
 import { configOrUpdatePageWidget, removePageWidget, editWidgetConfig } from 'state/page-config/actions';
+import { ROUTE_CLONE_WIDGET } from 'app-init/router';
 
 
-export const mapDispatchToProps = (dispatch, { match: { params } }) => ({
-  onDrop: ({ sourceWidgetId, sourceFrameId, targetFrameId }) => {
+export const mapDispatchToProps = (dispatch, { match: { params }, history }) => ({
+  onDrop: ({
+    sourceWidgetId, sourceFrameId, targetFrameId,
+  }) => {
     dispatch(configOrUpdatePageWidget(
       sourceWidgetId,
       sourceFrameId,
@@ -18,6 +22,16 @@ export const mapDispatchToProps = (dispatch, { match: { params } }) => ({
   },
   onClickDelete: frameId => dispatch(removePageWidget(frameId, params.pageCode)),
   onClickSettings: frameId => dispatch(editWidgetConfig(frameId, params.pageCode)),
+  onClickSaveAs: ({
+    widgetId, frameId, widgetAction,
+  }) => {
+    history.push(routeConverter(ROUTE_CLONE_WIDGET, {
+      parentCode: widgetId,
+      frameId,
+      pageCode: params.pageCode,
+      widgetAction,
+    }));
+  },
 });
 
 

--- a/src/ui/pages/config/DroppableWidgetFrame.js
+++ b/src/ui/pages/config/DroppableWidgetFrame.js
@@ -6,7 +6,9 @@ import frameDropTarget from 'ui/pages/config/frameDropTarget';
 import { configOrUpdatePageWidget } from 'state/page-config/actions';
 
 export const mapDispatchToProps = (dispatch, { match: { params } }) => ({
-  onDrop: ({ sourceWidgetId, sourceFrameId, targetFrameId }) => {
+  onDrop: ({
+    sourceWidgetId, sourceFrameId, targetFrameId,
+  }) => {
     dispatch(configOrUpdatePageWidget(
       sourceWidgetId,
       sourceFrameId,

--- a/src/ui/pages/config/PageConfigGridCol.js
+++ b/src/ui/pages/config/PageConfigGridCol.js
@@ -47,6 +47,7 @@ const PageConfigGridCol = ({ cellMap, cellKey, gridWidth }) => {
     classNameAr.push('PageConfigGridCol--frame');
     content = (
       <DecoratedWidgetFrame
+        widgetAction={col.widgetAction}
         frameId={col.framePos}
         frameName={col.frameDescr}
         frameIsMainFrame={col.frameIsMainFrame}

--- a/src/ui/pages/config/WidgetFrame.js
+++ b/src/ui/pages/config/WidgetFrame.js
@@ -14,12 +14,13 @@ class WidgetFrame extends Component {
   render() {
     const {
       widgetId, widgetName, widgetHasConfig, widgetStatus, frameId, frameName, frameIsMainFrame,
-      onClickDelete, connectDragSource, connectDropTarget, isOver, onClickSettings,
+      onClickDelete, connectDragSource, connectDropTarget, isOver, onClickSettings, onClickSaveAs,
+      widgetAction,
     } = this.props;
 
     let actionsMenu = null;
     if (widgetStatus !== WIDGET_STATUS_REMOVED) {
-      const configMenuItems = widgetHasConfig ?
+      const configMenuItems = widgetHasConfig && widgetAction ?
         [
           (
             <MenuItem
@@ -32,6 +33,22 @@ class WidgetFrame extends Component {
           ),
         ] :
         null;
+      const cloneMenuItems = widgetHasConfig && widgetAction ? [
+        (
+          <MenuItem
+            key="menu-saveAs"
+            className="WidgetFrame__saveAs-btn"
+            onClick={() => onClickSaveAs && onClickSaveAs({
+              widgetId,
+              widgetHasConfig,
+              frameId,
+              widgetAction,
+            })}
+          >
+            <FormattedMessage id="app.saveAs" />
+          </MenuItem>
+        ),
+      ] : null;
 
       actionsMenu = (
         <DropdownKebab
@@ -59,6 +76,8 @@ class WidgetFrame extends Component {
           </li>
 
           { configMenuItems }
+
+          {cloneMenuItems}
 
           <MenuItem
             className="WidgetFrame__delete-btn"
@@ -115,6 +134,7 @@ WidgetFrame.propTypes = {
   widgetName: PropTypes.string.isRequired,
   widgetHasConfig: PropTypes.bool,
   widgetStatus: PropTypes.oneOf([WIDGET_STATUS_MATCH, WIDGET_STATUS_DIFF, WIDGET_STATUS_REMOVED]),
+  widgetAction: PropTypes.string,
 
   /* eslint-disable react/no-unused-prop-types */
   frameId: PropTypes.number, // needed when it's droppable
@@ -123,6 +143,7 @@ WidgetFrame.propTypes = {
 
   onClickDelete: PropTypes.func,
   onClickSettings: PropTypes.func,
+  onClickSaveAs: PropTypes.func,
 
   // react-dnd
   connectDragSource: PropTypes.func,
@@ -133,6 +154,7 @@ WidgetFrame.propTypes = {
 WidgetFrame.defaultProps = {
   onClickDelete: null,
   onClickSettings: null,
+  onClickSaveAs: null,
   widgetHasConfig: false,
   widgetStatus: WIDGET_STATUS_MATCH,
   frameId: null,
@@ -140,6 +162,7 @@ WidgetFrame.defaultProps = {
   connectDragSource: null,
   connectDropTarget: null,
   isOver: false,
+  widgetAction: null,
 };
 
 

--- a/src/ui/widgets/clone/CloneWidgetFormContainer.js
+++ b/src/ui/widgets/clone/CloneWidgetFormContainer.js
@@ -1,0 +1,92 @@
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import { routeConverter } from '@entando/utils';
+import { submit, reduxForm } from 'redux-form';
+import { injectIntl } from 'react-intl';
+import { WidgetFormBody } from 'ui/widgets/common/WidgetForm';
+
+import { fetchLanguages } from 'state/languages/actions';
+import { removePageWidget, updatePageWidget } from 'state/page-config/actions';
+import { getActiveLanguages } from 'state/languages/selectors';
+import { getConfigMap } from 'state/page-config/selectors';
+import { fetchGroups } from 'state/groups/actions';
+import { getGroupsList } from 'state/groups/selectors';
+import { getSelectedWidgetDefaultUi, getSelectedParentWidget, getSelectedParentWidgetParameters } from 'state/widgets/selectors';
+import { initNewUserWidget, sendPostWidgets } from 'state/widgets/actions';
+import { initWidgetConfigPageWithConfigData, updateConfiguredPageWidget } from 'state/widget-config/actions';
+import { getLoading } from 'state/loading/selectors';
+
+import { setVisibleModal } from 'state/modal/actions';
+import { ROUTE_WIDGET_LIST } from 'app-init/router';
+import { ConfirmCancelModalID } from 'ui/common/cancel-modal/ConfirmCancelModal';
+
+const CONFIG_SIMPLE_PARAMETER = 'configSimpleParameter';
+const MODE_CLONE = 'clone';
+
+export const mapStateToProps = (state, { match: { params } }) => {
+  const { pageCode, parentCode } = params;
+  const pageConfig = getConfigMap(state) || {};
+  const targetConfig = pageConfig[pageCode] || [];
+  const widgetConfig = targetConfig[0] || {};
+  const initialValues = { config: { ...widgetConfig.config }, parentType: parentCode };
+  return ({
+    mode: MODE_CLONE,
+    groups: getGroupsList(state),
+    parentWidget: getSelectedParentWidget(state),
+    parentWidgetParameters: getSelectedParentWidgetParameters(state),
+    defaultUIField: getSelectedWidgetDefaultUi(state),
+    languages: getActiveLanguages(state),
+    loading: getLoading(state).fetchWidget,
+    initialValues,
+  });
+};
+
+export const mapDispatchToProps = (dispatch, { history, match: { params } }) => ({
+  onWillMount: () => {
+    const {
+      parentCode, widgetAction, pageCode, frameId,
+    } = params;
+    if (widgetAction && widgetAction === CONFIG_SIMPLE_PARAMETER) {
+      // navigate to specific form
+    }
+    dispatch(fetchGroups({ page: 1, pageSize: 0 }));
+    dispatch(fetchLanguages({ page: 1, pageSize: 0 }));
+    dispatch(initWidgetConfigPageWithConfigData(pageCode, parentCode, parseInt(frameId, 10)));
+    dispatch(initNewUserWidget(parentCode, true));
+  },
+  onSubmit: (values) => {
+    const jsonData = {
+      ...values,
+      configUi: values.configUi ? JSON.parse(values.configUi) : null,
+    };
+    return dispatch(sendPostWidgets(jsonData));
+  },
+  onReplaceSubmit: async (values) => {
+    const {
+      pageCode, frameId,
+    } = params;
+    const jsonData = {
+      ...values,
+      configUi: values.configUi ? JSON.parse(values.configUi) : null,
+    };
+    await dispatch(sendPostWidgets(jsonData));
+    await dispatch(removePageWidget(frameId, pageCode));
+    await dispatch(updatePageWidget(values.code, null, frameId, pageCode));
+    await dispatch(updateConfiguredPageWidget(
+      { ...values.config },
+      { pageCode, framePos: frameId, widgetCode: values.code },
+    ));
+  },
+  onSave: () => { dispatch(setVisibleModal('')); dispatch(submit('widget')); },
+  onCancel: () => dispatch(setVisibleModal(ConfirmCancelModalID)),
+  onDiscard: () => { dispatch(setVisibleModal('')); history.push(routeConverter(ROUTE_WIDGET_LIST)); },
+});
+
+const WidgetForm = injectIntl(reduxForm({
+  form: 'widget',
+  enableReinitialize: true,
+})(WidgetFormBody));
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps, null, {
+  pure: false,
+})(WidgetForm));

--- a/src/ui/widgets/clone/CloneWidgetPage.js
+++ b/src/ui/widgets/clone/CloneWidgetPage.js
@@ -1,0 +1,61 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { Breadcrumb, Grid, Row, Col } from 'patternfly-react';
+
+import BreadcrumbItem from 'ui/common/BreadcrumbItem';
+import InternalPage from 'ui/internal-page/InternalPage';
+import PageTitle from 'ui/internal-page/PageTitle';
+import CloneWidgetFormContainer from 'ui/widgets/clone/CloneWidgetFormContainer';
+import { ROUTE_WIDGET_LIST } from 'app-init/router';
+
+class CloneWidgetPage extends Component {
+  componentWillMount() {
+    this.props.onWillMount(this.props);
+  }
+
+  render() {
+    return (
+      <InternalPage className="CloneWidgetPage">
+        <Grid fluid>
+          <Row>
+            <Col xs={12}>
+              <Breadcrumb>
+                <BreadcrumbItem>
+                  <FormattedMessage id="menu.uxComponents" />
+                </BreadcrumbItem>
+                <BreadcrumbItem to={ROUTE_WIDGET_LIST}>
+                  <FormattedMessage id="menu.widgets" />
+                </BreadcrumbItem>
+                <BreadcrumbItem>
+                  <FormattedMessage id="menu.widgetClone" />
+                </BreadcrumbItem>
+                <BreadcrumbItem active>
+                  {this.props.widgetName}
+                </BreadcrumbItem>
+              </Breadcrumb>
+            </Col>
+          </Row>
+          <Row>
+            <Col xs={12}>
+              <PageTitle titleId="widget.page.clone.pageTitle" helpId="widget.help" />
+            </Col>
+          </Row>
+          <CloneWidgetFormContainer />
+        </Grid>
+      </InternalPage>
+    );
+  }
+}
+
+CloneWidgetPage.propTypes = {
+  onWillMount: PropTypes.func,
+  widgetName: PropTypes.string,
+};
+
+CloneWidgetPage.defaultProps = {
+  onWillMount: () => {},
+  widgetName: '',
+};
+
+export default CloneWidgetPage;

--- a/src/ui/widgets/common/WidgetForm.js
+++ b/src/ui/widgets/common/WidgetForm.js
@@ -15,6 +15,7 @@ import JsonCodeEditorRenderer from 'ui/common/form/JsonCodeEditorRenderer';
 import ConfirmCancelModalContainer from 'ui/common/cancel-modal/ConfirmCancelModalContainer';
 
 const MODE_NEW = 'new';
+const MODE_CLONE = 'clone';
 const maxLength30 = maxLength(30);
 const maxLength70 = maxLength(70);
 
@@ -99,6 +100,7 @@ export class WidgetFormBody extends Component {
       intl, dirty, onCancel, onDiscard, onSave,
       invalid, submitting, loading, mode,
       parentWidget, parentWidgetParameters,
+      onReplaceSubmit,
     } = this.props;
     const onSubmit = (ev) => {
       ev.preventDefault();
@@ -142,6 +144,18 @@ export class WidgetFormBody extends Component {
       defaultUITab = null;
     }
 
+    const renderSaveAndReplaceButton = MODE_CLONE ? (
+      <Button
+        className="pull-right FragmentForm__save--btn"
+        type="submit"
+        bsStyle="primary"
+        disabled={invalid || submitting}
+        onClick={this.props.handleSubmit(values => onReplaceSubmit({ ...values }))}
+      >
+        <FormattedMessage id="app.saveAndReplace" />
+      </Button>
+    ) : null;
+
     return (
       <Spinner loading={!!loading}>
         <form onSubmit={onSubmit} className="form-horizontal">
@@ -163,7 +177,7 @@ export class WidgetFormBody extends Component {
                   optionDisplayName="name"
                   defaultOptionId="app.chooseAnOption"
                 />
-                {(mode === 'edit' && parentWidget) && (
+                {((mode === 'edit' || mode === MODE_CLONE) && parentWidget) && (
                   <div className="form-group">
                     <Col xs={2} className="text-right">
                       <ControlLabel>
@@ -236,6 +250,7 @@ export class WidgetFormBody extends Component {
           <br />
           <Row>
             <Col xs={12}>
+              {renderSaveAndReplaceButton}
               <Button
                 className="pull-right FragmentForm__save--btn"
                 type="submit"
@@ -290,6 +305,7 @@ WidgetFormBody.propTypes = {
   onCancel: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
   loading: PropTypes.bool,
+  onReplaceSubmit: PropTypes.func,
 };
 
 WidgetFormBody.defaultProps = {
@@ -307,6 +323,7 @@ WidgetFormBody.defaultProps = {
   onChangeDefaultTitle: null,
   dirty: false,
   loading: false,
+  onReplaceSubmit: () => {},
 };
 
 const WidgetForm = reduxForm({

--- a/src/ui/widgets/common/WidgetForm.js
+++ b/src/ui/widgets/common/WidgetForm.js
@@ -15,6 +15,7 @@ import JsonCodeEditorRenderer from 'ui/common/form/JsonCodeEditorRenderer';
 import ConfirmCancelModalContainer from 'ui/common/cancel-modal/ConfirmCancelModalContainer';
 
 const MODE_NEW = 'new';
+const MODE_EDIT = 'edit';
 const MODE_CLONE = 'clone';
 const maxLength30 = maxLength(30);
 const maxLength70 = maxLength(70);
@@ -138,7 +139,7 @@ export class WidgetFormBody extends Component {
       </Tab>
     );
 
-    if (mode === 'edit') {
+    if (mode === MODE_EDIT) {
       codeField = null;
     } else {
       defaultUITab = null;
@@ -177,7 +178,7 @@ export class WidgetFormBody extends Component {
                   optionDisplayName="name"
                   defaultOptionId="app.chooseAnOption"
                 />
-                {((mode === 'edit' || mode === MODE_CLONE) && parentWidget) && (
+                {((mode === MODE_EDIT || mode === MODE_CLONE) && parentWidget) && (
                   <div className="form-group">
                     <Col xs={2} className="text-right">
                       <ControlLabel>

--- a/test/ui/pages/config/WidgetFrame.test.js
+++ b/test/ui/pages/config/WidgetFrame.test.js
@@ -9,6 +9,7 @@ const FRAME_ID = 1;
 const FRAME_NAME = 'The frame descr';
 const WIDGET_ID = 'widget_code';
 const WIDGET_NAME = 'The widget name';
+const WIDGET_ACTION = 'someAction';
 
 
 const connectDropTargetMock = jest.fn().mockImplementation(arg => arg);
@@ -152,6 +153,7 @@ describe('WidgetFrame (with widget that has config)', () => {
   beforeEach(() => {
     component = shallow((
       <WidgetFrame
+        widgetAction={WIDGET_ACTION}
         frameId={FRAME_ID}
         widgetId={WIDGET_ID}
         frameName={FRAME_NAME}


### PR DESCRIPTION
This PR implement AdminConsole analogue of cloning a widget. (This PR uses ConfigSimpleParameter approach always, as seen in AdminConsole, although in the second subtask of ENG-722 native config screen will be shown for widgets that have their own unique edit screens, that's why `src/ui/widgets/clone/CloneWidgetFormContainer.js` line 49 has that empty `if` block) 