### PR TITLE
ENG-977 destroy Profile Type form when navigating from edit profile

### DIFF
--- a/src/ui/roles/common/DeleteUserRoleModal.js
+++ b/src/ui/roles/common/DeleteUserRoleModal.js
@@ -65,7 +65,7 @@ class DeleteRoleModal extends React.Component {
           </thead>
           <tbody>
             {
-            userReferences.map(reference => (
+            userReferences.filter(ref => ref != null).map(reference => (
               <tr key={reference.username}>
                 <td>
                   {

--- a/src/ui/user-profile/common/UserProfileForm.js
+++ b/src/ui/user-profile/common/UserProfileForm.js
@@ -104,6 +104,10 @@ export class UserProfileFormBody extends Component {
     this.props.onWillMount(this.props);
   }
 
+  componentWillUnmount() {
+    this.props.onWillUnmount();
+  }
+
   render() {
     const {
       onSubmit, handleSubmit, invalid, submitting, defaultLanguage, languages,
@@ -297,6 +301,7 @@ UserProfileFormBody.propTypes = {
   })),
   profileTypes: PropTypes.arrayOf(PropTypes.shape({})),
   onProfileTypeChange: PropTypes.func,
+  onWillUnmount: PropTypes.func,
 };
 
 UserProfileFormBody.defaultProps = {
@@ -308,6 +313,7 @@ UserProfileFormBody.defaultProps = {
   onProfileTypeChange: () => {},
   selectedProfileType: '',
   userCurrentProfileType: '',
+  onWillUnmount: () => {},
 };
 
 

--- a/src/ui/user-profile/edit/EditUserProfileFormContainer.js
+++ b/src/ui/user-profile/edit/EditUserProfileFormContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { change, formValueSelector } from 'redux-form';
+import { change, formValueSelector, destroy } from 'redux-form';
 import { getUserProfile } from 'state/user-profile/selectors';
 import { fetchLanguages } from 'state/languages/actions';
 import { fetchProfileTypes, fetchProfileType } from 'state/profile-types/actions';
@@ -28,6 +28,9 @@ export const mapDispatchToProps = dispatch => ({
     dispatch(fetchProfileTypes({ page: 1, pageSize: 0 }));
     dispatch(fetchLanguages({ page: 1, pageSize: 0 }));
     dispatch(fetchUserProfile(username));
+  },
+  onWillUnmount: () => {
+    dispatch(destroy('ProfileType'));
   },
   onSubmit: (userprofile) => {
     dispatch(updateUserProfile(userprofile));


### PR DESCRIPTION
This PR contains:
- Fix for breaking Role reference modal, when sometimes in referenced array of users we come across with `null` values
- When unmounting the Edit User Profile screen, we should manually destroy ProfileType form, as it pollutes Add new Profile Type Screen