### PR TITLE
ENG-1129 implement FE validations for texts and numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "redux-mock-store": "^1.4.0",
     "redux-test-utils": "^0.2.2",
     "redux-thunk": "^2.3.0",
+    "regex-parser": "^2.2.11",
     "reselect": "^4.0.0",
     "sass-lint": "^1.13.1",
     "sass-loader": "^7.1.0",

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -360,6 +360,7 @@ export default {
     'validateForm.number': 'Must be a number.',
     'validateForm.minValue': 'Must be at least {min}',
     'validateForm.maxValue': 'Must be at most {max}.',
+    'validateForm.regex': 'Must match this regex: {regex}',
     'validateForm.email': 'Invalid email address.',
     'validateForm.alphaNumeric': 'Alphanumeric characters only.',
     'validateForm.widgetCode': '{name} contains invalid characters. Only alphanumeric characters and the underscore are allowed',

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -360,6 +360,7 @@ export default {
     'validateForm.number': 'Deve essere un numero',
     'validateForm.minValue': 'Deve essere minore {min}',
     'validateForm.maxValue': 'Deve essre maggiore {max}',
+    'validateForm.regex': 'Deve corrispondere a questa regex: {regex}',
     'validateForm.email': 'Indirizzo email non valido!',
     'validateForm.alphaNumeric': 'Solo caratteri alfanumerici',
     'validateForm.widgetCode': '{name} contiene caratteri non consentiti. Usare solo caratteri alfanumerici o undescore _',

--- a/src/locales/pt.js
+++ b/src/locales/pt.js
@@ -352,6 +352,7 @@ export default {
     'validateForm.number': 'Deve ser um número',
     'validateForm.minValue': 'Deve ter ao menos {min}',
     'validateForm.maxValue': 'Deve ter no máximo {max}',
+    'validateForm.regex': 'Deve corresponder a este regex: {regex}',
     'validateForm.email': 'Endereço de email inválido',
     'validateForm.alphaNumeric': 'Somente caracteres alfanuméricos',
     'validateForm.widgetCode': '{name} contém caracteres inválidos. Somente caracteres alfanuméricos e sublinhado _ são permitidos',

--- a/src/ui/profile-types/attributes/EditFormContainer.js
+++ b/src/ui/profile-types/attributes/EditFormContainer.js
@@ -50,6 +50,7 @@ export const mapDispatchToProps = (dispatch, { match: { params } }) => ({
     const payload = {
       ...values,
       validationRules: {
+        ...values.validationRules,
         rangeStartDate,
         rangeEndDate,
         equalDate,

--- a/src/ui/user-profile/common/UserProfileForm.js
+++ b/src/ui/user-profile/common/UserProfileForm.js
@@ -87,18 +87,17 @@ export class UserProfileFormBody extends Component {
   }
 
   generateValidatorFunc(value, validatorFuncName, validatorFunc, validatorArray, parseValueFunc) {
-    if (value === null || value === undefined) return;
+    if (value === null || value === undefined) {
+      return;
+    }
     const parsedValue = parseValueFunc ? parseValueFunc(value) : value;
     this.validators = this.validators || {};
-    if (this.validators[validatorFuncName]) {
-      if (!this.validators[validatorFuncName][value]) {
-        this.validators[validatorFuncName] = {
-          ...this.validators[validatorFuncName],
-          [value]: validatorFunc(parsedValue),
-        };
-      }
-    } else {
-      this.validators[validatorFuncName] = { [value]: validatorFunc(parsedValue) };
+    this.validators[validatorFuncName] = this.validators[validatorFuncName] || {};
+    if (!this.validators[validatorFuncName][value]) {
+      this.validators[validatorFuncName] = {
+        ...this.validators[validatorFuncName],
+        [value]: validatorFunc(parsedValue),
+      };
     }
     validatorArray.push(this.validators[validatorFuncName][value]);
   }

--- a/src/ui/user-profile/common/UserProfileForm.js
+++ b/src/ui/user-profile/common/UserProfileForm.js
@@ -86,20 +86,17 @@ export class UserProfileFormBody extends Component {
     this.props.onWillUnmount();
   }
 
-  generatetValidatorFunc(value, validatorFuncName, validatorFunc, validatorArray, parseValueFunc) {
-    if (value) {
-      if (this.validatorFuncName) {
-        if (this.validatorFuncName[value]) {
-          validatorArray.push(this.validatorFuncName[value]);
-        } else {
-          this.validatorFuncName[value] =
-          validatorFunc(parseValueFunc ? parseValueFunc(value) : value);
-        }
-      } else {
-        this.validatorFuncName =
-        { [value]: validatorFunc(parseValueFunc ? parseValueFunc(value) : value) };
+  generateValidatorFunc(value, validatorFuncName, validatorFunc, validatorArray, parseValueFunc) {
+    if (value == null) return;
+    const parsedValue = parseValueFunc ? parseValueFunc(value) : value;
+    if (this.validatorFuncName) {
+      if (this.validatorFuncName[value] == null) {
+        this.validatorFuncName[value] = validatorFunc(parsedValue);
       }
+    } else {
+      this.validatorFuncName = { [value]: validatorFunc(parsedValue) };
     }
+    validatorArray.push(this.validatorFuncName[value]);
   }
 
   renderField(attribute) {
@@ -108,13 +105,13 @@ export class UserProfileFormBody extends Component {
     const {
       minLength: textMinLen, maxLength: textMaxLen, regex, rangeEndNumber, rangeStartNumber,
     } = validationRules || {};
-    const validateArray = [];
+    const validateArray = [...(attribute.mandatory ? [required] : [])];
 
-    this.generatetValidatorFunc(textMinLen, 'minLength', minLength, validateArray);
-    this.generatetValidatorFunc(textMaxLen, 'maxLength', maxLength, validateArray);
-    this.generatetValidatorFunc(regex, 'regex', matchRegex, validateArray, RegexParser);
-    this.generatetValidatorFunc(rangeEndNumber, 'rangeEndNumber', maxValue, validateArray);
-    this.generatetValidatorFunc(rangeStartNumber, 'rangeStartNumber', minValue, validateArray);
+    this.generateValidatorFunc(textMinLen, 'minLength', minLength, validateArray);
+    this.generateValidatorFunc(textMaxLen, 'maxLength', maxLength, validateArray);
+    this.generateValidatorFunc(regex, 'regex', matchRegex, validateArray, RegexParser);
+    this.generateValidatorFunc(rangeEndNumber, 'rangeEndNumber', maxValue, validateArray);
+    this.generateValidatorFunc(rangeStartNumber, 'rangeStartNumber', minValue, validateArray);
 
     return (<Field
       key={attribute.code}

--- a/src/ui/user-profile/common/UserProfileForm.js
+++ b/src/ui/user-profile/common/UserProfileForm.js
@@ -89,14 +89,18 @@ export class UserProfileFormBody extends Component {
   generateValidatorFunc(value, validatorFuncName, validatorFunc, validatorArray, parseValueFunc) {
     if (value === null || value === undefined) return;
     const parsedValue = parseValueFunc ? parseValueFunc(value) : value;
-    if (this.validatorFuncName) {
-      if (!this.validatorFuncName[value]) {
-        this.validatorFuncName = { ...this.validatorFuncName, [value]: validatorFunc(parsedValue) };
+    this.validators = this.validators || {};
+    if (this.validators[validatorFuncName]) {
+      if (!this.validators[validatorFuncName][value]) {
+        this.validators[validatorFuncName] = {
+          ...this.validators[validatorFuncName],
+          [value]: validatorFunc(parsedValue),
+        };
       }
     } else {
-      this.validatorFuncName = { [value]: validatorFunc(parsedValue) };
+      this.validators[validatorFuncName] = { [value]: validatorFunc(parsedValue) };
     }
-    validatorArray.push(this.validatorFuncName[value]);
+    validatorArray.push(this.validators[validatorFuncName][value]);
   }
 
   renderField(attribute) {

--- a/src/ui/user-profile/common/UserProfileForm.js
+++ b/src/ui/user-profile/common/UserProfileForm.js
@@ -87,11 +87,11 @@ export class UserProfileFormBody extends Component {
   }
 
   generateValidatorFunc(value, validatorFuncName, validatorFunc, validatorArray, parseValueFunc) {
-    if (value == null) return;
+    if (value === null || value === undefined) return;
     const parsedValue = parseValueFunc ? parseValueFunc(value) : value;
     if (this.validatorFuncName) {
-      if (this.validatorFuncName[value] == null) {
-        this.validatorFuncName[value] = validatorFunc(parsedValue);
+      if (!this.validatorFuncName[value]) {
+        this.validatorFuncName = { ...this.validatorFuncName, [value]: validatorFunc(parsedValue) };
       }
     } else {
       this.validatorFuncName = { [value]: validatorFunc(parsedValue) };


### PR DESCRIPTION
In `generatetValidatorFunc` I use `this` to save functions, because if we do not "pre-compute" and "cache" the validator functions like `minLength` etc, and we just put `minLength(20)` into `validate` array as a `Field` prop, we get recursive rendering and maximum tree update depth error. So, that's a must have.