### PR TITLE
ENG-1276 avoiding name “Entando CMS” in widget list

### DIFF
--- a/src/state/page-config/selectors.js
+++ b/src/state/page-config/selectors.js
@@ -6,14 +6,19 @@ import { getListWidget, getWidgetsMap } from 'state/widgets/selectors';
 import { getSelectedPageTemplateCellMap, getSelectedPageTemplateMainFrame, getSelectedPageTemplateDefaultConfig } from 'state/page-templates/selectors';
 import { WIDGET_STATUS_MATCH, WIDGET_STATUS_DIFF, WIDGET_STATUS_REMOVED } from 'state/page-config/const';
 
+const renameCMSPluginName = ({ typology, pluginDesc, ...widget }) => ({
+  ...widget,
+  typology,
+  pluginDesc: typology === 'jacms' ? 'CMS' : typology,
+});
 
 const widgetGroupByCategory = (widgetList, locale) =>
 
   widgetList.reduce((acc, widget) => {
     if (acc[widget.typology]) {
-      acc[widget.typology].push({ ...widget, name: widget.titles[locale] });
+      acc[widget.typology].push({ ...renameCMSPluginName(widget), name: widget.titles[locale] });
     } else {
-      acc[widget.typology] = [{ ...widget, name: widget.titles[locale] }];
+      acc[widget.typology] = [{ ...renameCMSPluginName(widget), name: widget.titles[locale] }];
     }
     return acc;
   }, {});

--- a/src/state/page-config/selectors.js
+++ b/src/state/page-config/selectors.js
@@ -9,7 +9,7 @@ import { WIDGET_STATUS_MATCH, WIDGET_STATUS_DIFF, WIDGET_STATUS_REMOVED } from '
 const renameCMSPluginName = ({ typology, pluginDesc, ...widget }) => ({
   ...widget,
   typology,
-  pluginDesc: typology === 'jacms' ? 'CMS' : typology,
+  pluginDesc: typology === 'jacms' ? 'CMS' : pluginDesc,
 });
 
 const widgetGroupByCategory = (widgetList, locale) =>


### PR DESCRIPTION
I guess renaming the component name in entando-plugin-jacms is a no-no so I made a selector function to filter out "Entando CMS" to just "CMS"