### PR TITLE
ENG-1378 CSS rule for starting points (left/top) of content area

### DIFF
--- a/sass/internal-page/InternalPage.scss
+++ b/sass/internal-page/InternalPage.scss
@@ -205,12 +205,22 @@
 }
 
 // sass-lint:disable force-element-nesting class-name-format nesting-depth
-.layout-pf-fixed {
-  .AssetsList__footer {
-    left: 100px;
+.container-pf-nav-pf-vertical {
+  .startLeftPos {
+    left: #{$nav-pf-vertical-width + 14};
 
     .container {
-      max-width: calc(100% - 214px);
+      max-width: calc(100% - #{$nav-pf-vertical-width + 14});
+    }
+  }
+
+  &.collapsed-nav {
+    .startLeftPos {
+      left: 74px;
+
+      .container {
+        max-width: calc(100% - 74px);
+      }
     }
   }
 }

--- a/sass/internal-page/InternalPage.scss
+++ b/sass/internal-page/InternalPage.scss
@@ -214,6 +214,10 @@
     }
   }
 
+  .startTopPos {
+    top: 58px;
+  }
+
   &.collapsed-nav {
     .startLeftPos {
       left: 74px;


### PR DESCRIPTION
ideal for use in fixed header/footer/dialogs on different states (nav opened, non-legacy mode, etc). Implemented in fixed heading+breadcrumb in content form as well as the bottom control in content form