### PR TITLE
ENG-1418: removing wrong condition

### DIFF
--- a/src/ui/database/dump/DatabaseDumpTablePage.js
+++ b/src/ui/database/dump/DatabaseDumpTablePage.js
@@ -20,9 +20,9 @@ class DatabaseDumpTablePage extends PureComponent {
     this.props.fetchDumpTable();
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate() {
     const { dumpData, isModalOpen } = this.props;
-    if (!isModalOpen && dumpData.length === 0 && prevProps.dumpData !== dumpData) {
+    if (!isModalOpen && dumpData.length === 0) {
       this.props.fetchDumpTable();
     }
   }


### PR DESCRIPTION
This feature was tested and it was working fine during tests done on [ENG-1418](https://jira.entando.org/browse/ENG-1418) ticket, but for some reason, when the same test was done on [ENG-1356](https://jira.entando.org/browse/ENG-1356), the modal was not being opened.

After testing again locally, I was able to reproduce the issue, and the root cause was an condition I added to prevent the fetch to happen multiple times by comparing the prevProps `dumpData` with the new prop. For some reason, it was working during ENG-1418 tests, but now this condition was never match, so I removed it.