### PR TITLE
ENG-1747: unformatted page position in the page tree after cloning or adding new additional pages

### DIFF
--- a/sass/pages/common/PageTreeCompact.scss
+++ b/sass/pages/common/PageTreeCompact.scss
@@ -5,6 +5,13 @@
     font-size: 14px;
   }
 
+  &__column-wrapper {
+    width: calc(calc(100vw - 250px) * .2);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+
   .TreeNodeExpandedIcon,
   .TreeNodeFolderIcon,
   .RowSpinner {
@@ -64,7 +71,6 @@
     color: $color-rating-filter-star-empty;
   }
   // sass-lint:enable force-element-nesting, no-qualifying-elements, class-name-format
-
 }
 
 // Bootstrap overrides

--- a/src/ui/pages/common/PageTreeCompact.js
+++ b/src/ui/pages/common/PageTreeCompact.js
@@ -98,30 +98,32 @@ class PageTreeCompact extends Component {
           onClick={() => onRowClick(page)}
         >
           <td className={className.join(' ').trim()}>
-            <span
-              role="button"
-              tabIndex={i}
-              className="PageTreeCompact__icons-label"
-              style={{ marginLeft: page.depth * 24 }}
-              onClick={(e) => {
+            <div className="PageTreeCompact__column-wrapper">
+              <span
+                role="button"
+                tabIndex={i}
+                className="PageTreeCompact__icons-label"
+                style={{ marginLeft: page.depth * 16 }}
+                onClick={(e) => {
                 if (loadOnPageSelect && !page.isEmpty) e.stopPropagation();
                 onClickExpand();
               }}
-              onKeyDown={onClickExpand}
-            >
-              <TreeNodeExpandedIcon expanded={page.expanded} />
-              {!loadOnPageSelect && (
+                onKeyDown={onClickExpand}
+              >
+                <TreeNodeExpandedIcon expanded={page.expanded} />
+                {!loadOnPageSelect && (
                 <span className="PageTreeCompact__page-name">
                   { page.title }
                 </span>
               )}
-              <RowSpinner loading={!!page.loading} />
-            </span>
-            {loadOnPageSelect && (
+                <RowSpinner loading={!!page.loading} />
+              </span>
+              {loadOnPageSelect && (
               <span className="PageTreeCompact__page-name">
                 { page.title }
               </span>
             )}
+            </div>
           </td>
           <td className="text-center PageTreeCompact__status-col">
             <PageStatusIcon status={page.status} />

--- a/src/ui/pages/edit/PagesEditFormContainer.js
+++ b/src/ui/pages/edit/PagesEditFormContainer.js
@@ -9,7 +9,7 @@ import { getGroupsList } from 'state/groups/selectors';
 import { getPageTemplatesList } from 'state/page-templates/selectors';
 import { getCharsets, getContentTypes, getPageTreePages } from 'state/pages/selectors';
 import { ACTION_SAVE, ACTION_SAVE_AND_CONFIGURE, SEO_ENABLED } from 'state/pages/const';
-import { handleExpandPage, sendPutPage, fetchPageForm, clearTree } from 'state/pages/actions';
+import { sendPutPage, fetchPageForm } from 'state/pages/actions';
 import { fetchGroups } from 'state/groups/actions';
 import { fetchPageTemplates } from 'state/page-templates/actions';
 import { history, ROUTE_PAGE_TREE, ROUTE_PAGE_CONFIG } from 'app-init/router';
@@ -53,11 +53,9 @@ export const mapDispatchToProps = (dispatch, ownProps) => ({
       } else ownProps.onSave();
     }).catch(() => {}),
   onWillMount: ({ pageCode }) => {
-    dispatch(clearTree());
     dispatch(fetchLanguages({ page: 1, pageSize: 0 }));
     dispatch(fetchGroups({ page: 1, pageSize: 0 }));
     dispatch(fetchPageTemplates({ page: 1, pageSize: 0 }));
-    dispatch(handleExpandPage());
     dispatch(fetchPageForm(pageCode));
   },
   onFindTemplateClick: () => dispatch(setVisibleModal('FindTemplateModal')),

--- a/test/ui/pages/edit/PagesEditFormContainer.test.js
+++ b/test/ui/pages/edit/PagesEditFormContainer.test.js
@@ -100,7 +100,8 @@ describe('PagesEditFormContainer', () => {
       });
 
       it('dispatch clearTree', () => {
-        expect(dispatchMock).toHaveBeenCalledWith('clearTree_result');
+        // should not clear the page tree
+        expect(dispatchMock).not.toHaveBeenCalledWith('clearTree_result');
       });
 
       it('dispatch fetchLanguages', () => {
@@ -113,10 +114,6 @@ describe('PagesEditFormContainer', () => {
 
       it('dispatch fetchPageTemplates', () => {
         expect(dispatchMock).toHaveBeenCalledWith('fetchPageTemplates_result');
-      });
-
-      it('dispatch handleExpandPage', () => {
-        expect(dispatchMock).toHaveBeenCalledWith('handleExpandPage_result');
       });
 
       it('dispatch fetchPageForm', () => {


### PR DESCRIPTION
- Truncating menu text
- prevent tree to reset after a page is selected