### PR TITLE
ENG-2219 show all groups when adding a new page as admin

### DIFF
--- a/src/state/groups/actions.js
+++ b/src/state/groups/actions.js
@@ -226,6 +226,7 @@ export const fetchCurrentUserGroups = () => async (dispatch) => {
     const json = await response.json();
     if (response.ok) {
       const groups = json.payload;
+      dispatch(setGroups(groups));
       const myGroupPermissionsResponse = await getMyGroupPermissions();
       const myGroupPermissionsJson = await myGroupPermissionsResponse.json();
       if (myGroupPermissionsResponse.ok) {

--- a/src/state/groups/selectors.js
+++ b/src/state/groups/selectors.js
@@ -115,8 +115,17 @@ export const getCurrentUserGroups = createSelector(
 export const currentUserGroupsPermissionsFilter = permissions =>
   createSelector(
     getCurrentUserGroups,
-    groups => groups.filter(group =>
-      group.code === FREE_ACCESS_GROUP.code
-      || group.permissions.includes(ROLE_SUPERUSER)
-      || permissions.every(permission => group.permissions.includes(permission))),
+    getGroupsList,
+    (currentUserGroups, allGroups) => {
+      const isAdmin = currentUserGroups.some(group => group.permissions
+        && group.permissions.includes(ROLE_SUPERUSER));
+      if (isAdmin) {
+        return allGroups;
+      }
+      return currentUserGroups.filter(group => (
+        group.code === FREE_ACCESS_GROUP.code
+        || group.permissions.includes(ROLE_SUPERUSER)
+        || permissions.every(permission => group.permissions.includes(permission))
+      ));
+    },
   );

--- a/test/state/groups/actions.test.js
+++ b/test/state/groups/actions.test.js
@@ -394,8 +394,11 @@ describe('state/groups/actions', () => {
 
       store.dispatch(fetchCurrentUserGroups()).then(() => {
         const actions = store.getActions();
-        expect(actions).toHaveLength(1);
+        expect(actions).toHaveLength(2);
         expect(actions[0]).toEqual({
+          type: SET_GROUPS, payload: { groups: LIST_GROUPS_OK },
+        });
+        expect(actions[1]).toEqual({
           type: SET_CURRENT_USER_GROUPS, payload: { groups: CURRENT_USER_GROUPS },
         });
         done();

--- a/test/state/groups/selectors.test.js
+++ b/test/state/groups/selectors.test.js
@@ -48,22 +48,6 @@ describe('state/groups/selectors', () => {
 
   it('verify currentUserGroupsPermissionsFilter', () => {
     const getCurrentUserGroupsWithManagePages = currentUserGroupsPermissionsFilter(['managePages']);
-    expect(getCurrentUserGroupsWithManagePages(GROUPS_NORMALIZED)).toEqual([
-      {
-        code: 'administrators',
-        name: 'Administrators',
-        permissions: ['superuser'],
-      },
-      {
-        code: 'free',
-        name: 'Free Access',
-        permissions: [],
-      },
-      {
-        code: 'bpm_admin',
-        name: 'Bpm Admin',
-        permissions: ['managePages'],
-      },
-    ]);
+    expect(getCurrentUserGroupsWithManagePages(GROUPS_NORMALIZED)).toEqual(LIST_GROUPS_OK);
   });
 });


### PR DESCRIPTION
Please consider this as a workaround, since this groups fetching logic should be on the backend.