### PR TITLE
ENG-2229: fixing image upload issue

### DIFF
--- a/sass/users/common/ProfileImageUploader.scss
+++ b/sass/users/common/ProfileImageUploader.scss
@@ -4,13 +4,21 @@
     padding: 0;
     float: none;
     border: 0;
+    border-radius: 50%;
     outline: none;
-    background-color: transparent !important;
+    background-color: $color-ecr-component-border;
     box-shadow: none !important;
+    border: solid 2px $color-ecr-component-border !important;
+  }
+
+  & > button {
+    border: solid 2px $color-ecr-component-border !important;
   }
 
   & button:disabled {
-    background-color: transparent !important;
+    img {
+      opacity: .5;
+    }
   }
 
   & .caret {
@@ -22,7 +30,7 @@
   }
 
   & button:hover {
-    background-color: transparent;
+    background-color: $color-ecr-component-border;
   }
 
   &__file-upload {

--- a/src/state/file-browser/actions.js
+++ b/src/state/file-browser/actions.js
@@ -228,19 +228,22 @@ export const sendDeleteFile = values => (dispatch, getState) => (
   })
 );
 
-const generalBodyApi = (apiFunc, loader) => (...args) => (dispatch) => {
-  createFileObject(...args).then((obj) => {
-    dispatch(toggleLoading(loader));
-    apiFunc(obj).then(() => {
-      dispatch(addToast({ id: 'fileBrowser.uploadFileComplete' }, TOAST_SUCCESS));
+const generalBodyApi = (apiFunc, loader) => (...args) => dispatch =>
+  new Promise((resolve, reject) => {
+    createFileObject(...args).then((obj) => {
       dispatch(toggleLoading(loader));
-    }).catch((error) => {
-      dispatch(toggleLoading(loader));
-      const message = { id: 'fileBrowser.uploadFileError', values: { errmsg: error } };
-      dispatch(message, TOAST_ERROR);
+      apiFunc(obj).then(() => {
+        dispatch(addToast({ id: 'fileBrowser.uploadFileComplete' }, TOAST_SUCCESS));
+        dispatch(toggleLoading(loader));
+        resolve();
+      }).catch((error) => {
+        dispatch(toggleLoading(loader));
+        const message = { id: 'fileBrowser.uploadFileError', values: { errmsg: error } };
+        dispatch(message, TOAST_ERROR);
+        reject();
+      });
     });
   });
-};
 
 export const uploadFile = (file, currentPath, loader = 'uploadFile', protectedFolder = false) =>
   dispatch => new Promise((resolve) => {
@@ -249,15 +252,17 @@ export const uploadFile = (file, currentPath, loader = 'uploadFile', protectedFo
     getFile(queryString).then((response) => {
       response.json().then((json) => {
         if (response.status === 404) {
-          dispatch(generalBodyApi(sendPostFile, loader)(protectedFolder, currentPath, file));
+          dispatch(generalBodyApi(sendPostFile, loader)(protectedFolder, currentPath, file))
+            .then(resolve);
         } else if (response.ok) {
-          dispatch(generalBodyApi(sendPutFile, loader)(protectedFolder, currentPath, file));
+          dispatch(generalBodyApi(sendPutFile, loader)(protectedFolder, currentPath, file))
+            .then(resolve);
         } else {
           dispatch(toggleLoading(loader));
           dispatch(addErrors(json.errors.map(e => e.message)));
           json.errors.forEach(err => dispatch(addToast(err.message, TOAST_ERROR)));
+          resolve();
         }
-        resolve();
       });
     }).catch(() => {});
   });


### PR DESCRIPTION
The promise returned by `uploadFile` was being resolved before the image was really persisted in the file browser, the callback of this was setting the <img> url at the tag element to show up the uploaded image, but on cloud environment where upload takes some time to complete, the img tag was not being able to display the image cause at the moment it tried to show, the image was not yet in the file browser.