### PR TITLE
ENG-2177 fix tutorial slow display navigatable

### DIFF
--- a/src/ui/app-tour/AppTour.js
+++ b/src/ui/app-tour/AppTour.js
@@ -403,7 +403,9 @@ class AppTour extends React.Component {
     const {
       wizardEnabled, appTourLastStep, appTourProgress, lockBodyScroll, customOffset,
     } = this.props;
-    if (!wizardEnabled || appTourProgress === APP_TOUR_CANCELLED) return null;
+    if (wizardEnabled === false || appTourProgress === APP_TOUR_CANCELLED) {
+      return null;
+    }
     const maskName = [1, 12, 14, 15].includes(appTourLastStep) ? 'Mask' : '';
     const scrollDuration = appTourLastStep === 5 ? 600 : 150;
     const scrollLock = window.innerWidth > 1024;
@@ -466,7 +468,7 @@ AppTour.propTypes = {
 };
 
 AppTour.defaultProps = {
-  wizardEnabled: false,
+  wizardEnabled: true,
   username: '',
   appTourProgress: '',
   appTourLastStep: 1,


### PR DESCRIPTION
- Make wizardEnabled default to `true` to prevent user to navigate until we have real value from API