### PR TITLE
ENG-2082: cleaning up warnings on jest

### DIFF
--- a/config/output.js
+++ b/config/output.js
@@ -1,0 +1,27 @@
+/* eslint-disable no-console */
+
+'use strict';
+
+const consoleWarning = console.warn;
+
+global.console = {
+  // we want to filter out some warnings to have a clear console
+  warn: jest.fn().mockImplementation((message) => {
+    if (
+    // Filtering out the above warning as it is throw by a deprecated library called `Recompose`
+    // which is being used by v3-patternfly which is also deprecated:
+    // React.createFactory() is deprecated and will be removed in a future major release.
+    // Consider using JSX or use React.createElement() directly instead.
+      !message.includes('React.createFactory()')
+    // we are aware of unsafe lifecycles methods
+    && !message.includes('react-unsafe-component-lifecycles')
+    ) {
+      consoleWarning(message);
+    }
+  }),
+
+  error: console.error,
+  log: console.log,
+  info: console.info,
+  debug: console.debug,
+};

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     ],
     "setupFiles": [
       "<rootDir>/config/polyfills.js",
+      "<rootDir>/config/output.js",
       "jest-localstorage-mock"
     ],
     "testMatch": [

--- a/src/ui/fragments/list/FragmentListTable.js
+++ b/src/ui/fragments/list/FragmentListTable.js
@@ -125,7 +125,6 @@ class FragmentListTable extends Component {
   }
 
   render() {
-    console.log('FragmentListTable rendered');
     return (
       <div className="FragmentListTable">
         <Spinner loading={!!this.props.loading} >

--- a/src/ui/fragments/list/ListFragmentPage.js
+++ b/src/ui/fragments/list/ListFragmentPage.js
@@ -34,7 +34,6 @@ export class ListFragmentPageBody extends Component {
   }
 
   render() {
-    console.log('ListFragmentPageBody rendered');
     return (
       <InternalPage className="ListFragmentPage">
         <Grid fluid>


### PR DESCRIPTION
https://entando.myjetbrains.com/youtrack/issue/ENG-2082

All warnings being logged on tests were related to two issues:

```
React.createFactory() is deprecated and will be removed in a future major release. Consider using JSX or use React.createElement() directly instead.
```
This was being thrown by [Recompose](https://github.com/acdlite/recompose) a deprecated library that is no longer being supported, although Entando is not directly importing Recompose, but patternfly-v3 is, another deprecated library our system relies on which means we won't have an update that will solve this warning at point in time.

```
react-unsafe-component-lifecycles
```
This warning is basically React telling us that methods like `componentWill*` will be deprecated at some point in time, and we should get rid of it by refactoring code or changing to the `UNSAFE_` version.

So I wrote a mocking function that filters out these warnings to have a cleaner console