### PR TITLE
ENG-2464: install button to always rely on latestVersion attribute

### DIFF
--- a/src/ui/component-repository/components/item/install-controls/InstallButton.js
+++ b/src/ui/component-repository/components/item/install-controls/InstallButton.js
@@ -71,7 +71,7 @@ const InstallButton = ({
           : (
             <Button
               bsStyle="primary"
-              onClick={() => onInstall(component)}
+              onClick={() => onInstall(component, (component.latestVersion || {}).version)}
             >
               <FormattedMessage id="componentRepository.components.install" />
             </Button >


### PR DESCRIPTION
When only one version is available, we don't render the dropdown button, instead we are rendering a simple button and it wasn't sending the latestVersion value, as the old API was handling the default value as `latest` but the new one doesn't support it anymore.