### PR TITLE
ENG-2642 Invoke fetchLanguages() in PageTreePageContainer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -320,9 +320,9 @@
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "@entando/apimanager": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/@entando/apimanager/-/apimanager-6.6.4.tgz",
-      "integrity": "sha512-vq2aGizHcNPxOfyseCHbn8HCIXFl61PGImAQaMwgCNlHCpuSBTOn6sRobSQ5vx4ASScZS8D0B/zl5m89CwcDJQ==",
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/@entando/apimanager/-/apimanager-6.6.6.tgz",
+      "integrity": "sha512-94UvDy91unjVq9OUoZ2mIibFfDuwkQq2Bqp5T69eemSQ+r+drXKOaVl5LEa8DxQbZh+JXn8580cIXVM+H47cSQ==",
       "requires": {
         "@entando/messages": "^1.0.5",
         "@entando/utils": "^2.4.2",

--- a/src/ui/pages/list/PageTreePageContainer.js
+++ b/src/ui/pages/list/PageTreePageContainer.js
@@ -14,6 +14,7 @@ import { MANAGE_PAGES_PERMISSION } from 'state/permissions/const';
 import { setAppTourLastStep } from 'state/app-tour/actions';
 import { APP_TOUR_HOMEPAGE_CODEREF, APP_TOUR_CANCELLED } from 'state/app-tour/const';
 import { getAppTourProgress } from 'state/app-tour/selectors';
+import { fetchLanguages } from 'state/languages/actions';
 
 export const mapStateToProps = state => ({
   locale: getLocale(state),
@@ -38,6 +39,7 @@ export const mapDispatchToProps = dispatch => ({
         }
       })
       .catch(() => dispatch(toggleLoading('pageTree')));
+    dispatch(fetchLanguages({ page: 1, pageSize: 0 }));
   },
   onClear: () => {
     dispatch(clearSearchPage());


### PR DESCRIPTION
* Fixes page title not falling back to default language title when non-default language title is empty