### PR TITLE
ENG-2680 Allow pagination total items to be zero

### DIFF
--- a/src/state/pagination/reducer.js
+++ b/src/state/pagination/reducer.js
@@ -27,7 +27,7 @@ const isPageSizeValid = (pageSize) => {
   return true;
 };
 
-const isTotalItemsValid = totalItems => isInteger(totalItems) && totalItems > 0;
+const isTotalItemsValid = totalItems => isInteger(totalItems) && totalItems >= 0;
 
 const isLastPageValid = (lastPage) => {
   if (!isInteger(lastPage)) {

--- a/test/state/pagination/reducer.test.js
+++ b/test/state/pagination/reducer.test.js
@@ -110,7 +110,7 @@ describe('pagination reducer', () => {
         expect(state).toEqual(defaultState);
       });
 
-      it('should define page if totalItems is numeric', () => {
+      it('should define page if totalItems is numeric and a positive integer', () => {
         const state = reducer(defaultState, setPage({
           ...correctBody,
           totalItems: '10',
@@ -119,6 +119,17 @@ describe('pagination reducer', () => {
         expect(state).toHaveProperty('global.pageSize', 2);
         expect(state).toHaveProperty('global.lastPage', 3);
         expect(state).toHaveProperty('global.totalItems', 10);
+      });
+
+      it('should define page if totalItems is zero', () => {
+        const state = reducer(defaultState, setPage({
+          ...correctBody,
+          totalItems: 0,
+        }));
+        expect(state).toHaveProperty('global.page', 1);
+        expect(state).toHaveProperty('global.pageSize', 2);
+        expect(state).toHaveProperty('global.lastPage', 3);
+        expect(state).toHaveProperty('global.totalItems', 0);
       });
     });
 


### PR DESCRIPTION
* Fixes tables/lists not showing updated paginators when `totaltems` is zero