### PR TITLE
ENG-2687: keep tabs components mounted to fix validation issues

### DIFF
--- a/src/ui/pages/common/SeoInfo.js
+++ b/src/ui/pages/common/SeoInfo.js
@@ -23,7 +23,7 @@ const SeoInfo = ({
   formId,
 }) =>
   (languages && languages.length ? (
-    <Tabs id="basic-tabs" defaultActiveKey={0} className="SeoInfo" mountOnEnter unmountOnExit>
+    <Tabs id="basic-tabs" defaultActiveKey={0} className="SeoInfo">
       {
       languages.map((lang, i) => (
         <Tab key={lang.code} eventKey={i} title={`${lang.code.toUpperCase()}${i === 0 ? '*' : ''}`} >


### PR DESCRIPTION
`mountOnEnter` and `unmountOnExit` props were keeping the unselected tabs unmounted, and unmounted component doesn't validate itself through redux-forms. Removing these props makes the fields hidden but mounted, so required fields on hidden tabs will start to validate as we want.