### PR TITLE
ENG-2714: fixing copy to all languages issue

### DIFF
--- a/src/state/edit-content/actions.js
+++ b/src/state/edit-content/actions.js
@@ -90,6 +90,9 @@ export const copyAttributeEngValue = (attribute, attributeType) => (dispatch, ge
     case TYPE_EMAIL:
     case TYPE_IMAGE:
     case TYPE_LINK: {
+      if (!attribute.values) {
+        return attribute;
+      }
       const { [deflang]: mainlangvalue } = attribute.values;
       const newValues = otherLanguages.reduce((acc, key) => (
         { ...acc, [key]: isObject(mainlangvalue) ? cloneDeep(mainlangvalue) : mainlangvalue }


### PR DESCRIPTION
some attributes like `Link`, when not fulfilled, doesn't return an object, so it can't be destructured.