### PR TITLE
ENG-2900 fix tab recalling modal

### DIFF
--- a/src/ui/component-repository/components/list/BundleListGridView.js
+++ b/src/ui/component-repository/components/list/BundleListGridView.js
@@ -28,10 +28,10 @@ const BundleListGridView =
             >
               <div
                 role="button"
-                tabIndex={-1}
+                tabIndex={0}
                 className="ComponentList__component-wrapper"
                 onClick={() => openComponentManagementModal(bundle)}
-                onKeyDown={() => openComponentManagementModal(bundle)}
+                onKeyDown={() => {}}
               >
 
                 <div className="ComponentList__component-image-wrapper">

--- a/src/ui/component-repository/components/list/BundleListListView.js
+++ b/src/ui/component-repository/components/list/BundleListListView.js
@@ -21,10 +21,10 @@ const BundleListListView =
           <div
             key={`${bundle.gitRepoAddress}-${bundle.id}`}
             role="button"
-            tabIndex={-1}
+            tabIndex={0}
             className="ComponentList__list-item"
             onClick={() => openComponentManagementModal(bundle)}
-            onKeyDown={() => openComponentManagementModal(bundle)}
+            onKeyDown={() => {}}
           >
             <div key={`${bundle.gitRepoAddress}-${bundle.id}`} className="equal">
               <div className="ComponentList__component-image-wrapper">

--- a/src/ui/component-repository/components/list/ComponentListGridView.js
+++ b/src/ui/component-repository/components/list/ComponentListGridView.js
@@ -32,9 +32,9 @@ const ComponentListGridView =
             <div
               className="ComponentList__component-image-wrapper"
               role="button"
-              tabIndex={-1}
+              tabIndex={0}
               onClick={() => openComponentManagementModal(component)}
-              onKeyDown={() => openComponentManagementModal(component)}
+              onKeyDown={() => {}}
             >
               <ComponentImage component={component} />
             </div>
@@ -43,9 +43,9 @@ const ComponentListGridView =
               <div
                 className="ComponentList__component-content"
                 role="button"
-                tabIndex={-1}
+                tabIndex={0}
                 onClick={() => openComponentManagementModal(component)}
-                onKeyDown={() => openComponentManagementModal(component)}
+                onKeyDown={() => {}}
               >
                 <p className="ComponentList__component-category">
                   {component.componentTypes

--- a/src/ui/component-repository/components/list/ComponentListListView.js
+++ b/src/ui/component-repository/components/list/ComponentListListView.js
@@ -25,9 +25,9 @@ const ComponentListListView =
             <div
               className="ComponentList__component-image-wrapper"
               role="button"
-              tabIndex={-1}
+              tabIndex={0}
               onClick={() => openComponentManagementModal(component)}
-              onKeyDown={() => openComponentManagementModal(component)}
+              onKeyDown={() => {}}
             >
               <ComponentImage component={component} />
             </div>
@@ -35,9 +35,9 @@ const ComponentListListView =
               <div
                 className="ComponentList__component-content"
                 role="button"
-                tabIndex={-1}
+                tabIndex={0}
                 onClick={() => openComponentManagementModal(component)}
-                onKeyDown={() => openComponentManagementModal(component)}
+                onKeyDown={() => {}}
               >
                 <p className="ComponentList__component-category">
                   {component.componentTypes


### PR DESCRIPTION
`onKeyDown` was causing a "click" on an element and the modal was re-opening once user was hitting tab or any other key. I cannot remove it completely as linter is throwing error. I also dont want to put disable line since it looks ugly.