### PR TITLE
ENG-2866: ensuring list mode on single content modal picker

### DIFF
--- a/src/api/contents.js
+++ b/src/api/contents.js
@@ -3,10 +3,11 @@ import {
   MOCK_CONTENTS_STATUS,
   RESPONSE_CONTENTS_OK, RESPONSE_DELETE_OK, RESPONSE_PUBLISH_OK, RESPONSE_SINGLE_CONTENT,
 } from 'test/mocks/contents';
+import { MODE_LIST } from 'state/contents/const';
 
 const contentsPath = '/api/plugins/cms/contents';
 
-export const getContents = (page, params = '', mode = 'list') => makeRequest({
+export const getContents = (page, params = '', mode = MODE_LIST) => makeRequest({
   uri: `${contentsPath}${params}${params ? '&' : '?'}mode=${mode}`,
   method: METHODS.GET,
   contentType: 'application/json',

--- a/src/state/contents/actions.js
+++ b/src/state/contents/actions.js
@@ -158,6 +158,7 @@ export const fetchContentsWithFilters = (
   quickFilterStatusParam = '',
   quickFilterOwnerGroup,
   joinGroupsToParse,
+  mode = 'full',
 ) => (dispatch, getState) => {
   const state = getState();
   const pagination = newPagination || getPagination(state, NAMESPACE_CONTENTS);
@@ -222,7 +223,7 @@ export const fetchContentsWithFilters = (
     return null;
   });
   query = `${convertToQueryString({ formValues, operators, sorting })}${categories}${quickFilterStatusParam || published}${ownerGroupQuery}${joinGroupsQuery}`;
-  return dispatch(fetchContents(pagination, query, NAMESPACE_CONTENTS, 'full'));
+  return dispatch(fetchContents(pagination, query, NAMESPACE_CONTENTS, mode));
 };
 
 export const fetchContentsWithTabs = (
@@ -230,6 +231,7 @@ export const fetchContentsWithTabs = (
   newSort,
   ownerGroup,
   joinGroupsToParse,
+  mode = 'full',
 ) => (dispatch, getState) => {
   const state = getState();
   const pagination = page || getPagination(state, NAMESPACE_CONTENTS);
@@ -264,19 +266,19 @@ export const fetchContentsWithTabs = (
   const joinGroupsQuery = (joinGroups && joinGroups.length > 0)
     ? joinGroups.reduce((acc, curr, index) => `${acc}&forLinkingWithExtraGroups[${index}]=${curr}`, '') : '';
   const params = `${query}${ownerGroupQuery}${joinGroupsQuery}`;
-  return dispatch(fetchContents(pagination, params, NAMESPACE_CONTENTS, 'full'));
+  return dispatch(fetchContents(pagination, params, NAMESPACE_CONTENTS, mode));
 };
 
 export const fetchContentsPaged = ({
   params, page, sort, tabSearch,
-  status, ownerGroup, joinGroups,
+  status, ownerGroup, joinGroups, mode,
 } = {}) => (dispatch) => {
   if (tabSearch) {
-    return dispatch(fetchContentsWithTabs(page, sort, ownerGroup, joinGroups));
+    return dispatch(fetchContentsWithTabs(page, sort, ownerGroup, joinGroups, mode));
   }
   return dispatch(fetchContentsWithFilters(
     params, page, sort,
-    status, ownerGroup, joinGroups,
+    status, ownerGroup, joinGroups, mode,
   ));
 };
 

--- a/src/state/contents/actions.js
+++ b/src/state/contents/actions.js
@@ -12,6 +12,7 @@ import {
   getStatusChecked, getAccessChecked, getAuthorChecked, getCurrentQuickFilter,
   getSortingColumns, getCurrentAuthorShow, getCurrentStatusShow,
 } from 'state/contents/selectors';
+import { MODE_FULL } from 'state/contents/const';
 import { addErrors, addToast, clearErrors, TOAST_ERROR } from '@entando/messages';
 import {
   SET_CONTENTS, SET_QUICK_FILTER, SET_CONTENT_CATEGORY_FILTER,
@@ -158,7 +159,7 @@ export const fetchContentsWithFilters = (
   quickFilterStatusParam = '',
   quickFilterOwnerGroup,
   joinGroupsToParse,
-  mode = 'full',
+  mode = MODE_FULL,
 ) => (dispatch, getState) => {
   const state = getState();
   const pagination = newPagination || getPagination(state, NAMESPACE_CONTENTS);
@@ -184,7 +185,7 @@ export const fetchContentsWithFilters = (
       ...(qfValue && { [id]: FILTER_OPERATORS.LIKE }),
     };
     query = `${convertToQueryString({ formValues, operators, sorting })}&${params}${quickFilterStatusParam}${ownerGroupQuery}${joinGroupsQuery}`;
-    return dispatch(fetchContents(pagination, query, NAMESPACE_CONTENTS, 'full'));
+    return dispatch(fetchContents(pagination, query, NAMESPACE_CONTENTS, mode));
   }
   if (qfValue) {
     filters.push({ att: id, value: qfValue, operator: FILTER_OPERATORS.LIKE });
@@ -231,7 +232,7 @@ export const fetchContentsWithTabs = (
   newSort,
   ownerGroup,
   joinGroupsToParse,
-  mode = 'full',
+  mode = MODE_FULL,
 ) => (dispatch, getState) => {
   const state = getState();
   const pagination = page || getPagination(state, NAMESPACE_CONTENTS);

--- a/src/state/contents/const.js
+++ b/src/state/contents/const.js
@@ -4,3 +4,6 @@ export const SORT_ATTRIBUTE_REPLACES = {
   onLine: 'status',
   code: 'id',
 };
+
+export const MODE_FULL = 'full';
+export const MODE_LIST = 'list';

--- a/src/ui/widget-forms/contents-filter/ContentsFilterBrowserContainer.js
+++ b/src/ui/widget-forms/contents-filter/ContentsFilterBrowserContainer.js
@@ -95,6 +95,8 @@ export const mapStateToProps = (state) => {
   });
 };
 
+const mode = 'list';
+
 export const mapDispatchToProps = (dispatch, {
   compatibility: { ownerGroup, joinGroups } = {},
   fetchOnMount,
@@ -102,7 +104,9 @@ export const mapDispatchToProps = (dispatch, {
   onDidMount: () => {
     dispatch(setCurrentStatusShow('published'));
     if (fetchOnMount) {
-      dispatch(fetchContentsPaged({ status: '&status=published', ownerGroup, joinGroups }));
+      dispatch(fetchContentsPaged({
+        status: '&status=published', ownerGroup, joinGroups, mode,
+      }));
     }
     dispatch(fetchCategoryTree());
     dispatch(fetchContentTypeListPaged(noPage));
@@ -117,6 +121,7 @@ export const mapDispatchToProps = (dispatch, {
     status: STATUS_PUBLISHED,
     ownerGroup,
     joinGroups,
+    mode,
   })),
   onSetTabSearch: tabSearch => dispatch(setTabSearch(tabSearch)),
   onCheckStatus: status => dispatch(checkStatus(status)),
@@ -131,6 +136,7 @@ export const mapDispatchToProps = (dispatch, {
       status: STATUS_PUBLISHED,
       ownerGroup,
       joinGroups,
+      mode,
     }));
   },
   onSetCurrentStatusShow: (status, author) => {
@@ -141,11 +147,14 @@ export const mapDispatchToProps = (dispatch, {
       status: '&status=published',
       ownerGroup,
       joinGroups,
+      mode,
     }));
   },
   onAdvancedFilterSearch: () => {
     dispatch(resetAuthorStatus());
-    dispatch(fetchContentsPaged({ status: '&status=published', ownerGroup, joinGroups }));
+    dispatch(fetchContentsPaged({
+      status: '&status=published', ownerGroup, joinGroups, mode,
+    }));
   },
   onSetCurrentColumnsShow: columnOrder => dispatch(setColumnOrder(columnOrder, 'contentFilterBrowser')),
   onSetContentType: contentType => dispatch(setContentType(contentType)),

--- a/src/ui/widget-forms/contents-filter/ContentsFilterBrowserContainer.js
+++ b/src/ui/widget-forms/contents-filter/ContentsFilterBrowserContainer.js
@@ -12,6 +12,7 @@ import {
   setTabSearch,
   leaveContentsPage,
 } from 'state/contents/actions';
+import { MODE_LIST } from 'state/contents/const';
 import { getPagination } from 'state/pagination/selectors';
 import { NAMESPACE_CONTENTS } from 'state/pagination/const';
 import { getLoading } from 'state/loading/selectors';
@@ -95,8 +96,6 @@ export const mapStateToProps = (state) => {
   });
 };
 
-const mode = 'list';
-
 export const mapDispatchToProps = (dispatch, {
   compatibility: { ownerGroup, joinGroups } = {},
   fetchOnMount,
@@ -105,7 +104,7 @@ export const mapDispatchToProps = (dispatch, {
     dispatch(setCurrentStatusShow('published'));
     if (fetchOnMount) {
       dispatch(fetchContentsPaged({
-        status: '&status=published', ownerGroup, joinGroups, mode,
+        status: '&status=published', ownerGroup, joinGroups, MODE_LIST,
       }));
     }
     dispatch(fetchCategoryTree());
@@ -121,7 +120,7 @@ export const mapDispatchToProps = (dispatch, {
     status: STATUS_PUBLISHED,
     ownerGroup,
     joinGroups,
-    mode,
+    MODE_LIST,
   })),
   onSetTabSearch: tabSearch => dispatch(setTabSearch(tabSearch)),
   onCheckStatus: status => dispatch(checkStatus(status)),
@@ -136,7 +135,7 @@ export const mapDispatchToProps = (dispatch, {
       status: STATUS_PUBLISHED,
       ownerGroup,
       joinGroups,
-      mode,
+      MODE_LIST,
     }));
   },
   onSetCurrentStatusShow: (status, author) => {
@@ -147,13 +146,13 @@ export const mapDispatchToProps = (dispatch, {
       status: '&status=published',
       ownerGroup,
       joinGroups,
-      mode,
+      MODE_LIST,
     }));
   },
   onAdvancedFilterSearch: () => {
     dispatch(resetAuthorStatus());
     dispatch(fetchContentsPaged({
-      status: '&status=published', ownerGroup, joinGroups, mode,
+      status: '&status=published', ownerGroup, joinGroups, MODE_LIST,
     }));
   },
   onSetCurrentColumnsShow: columnOrder => dispatch(setColumnOrder(columnOrder, 'contentFilterBrowser')),


### PR DESCRIPTION
- Ensuring that the content search modal will always call the contents API with `list` mode.
- Since `fetchContentsPaged` is being used through many places, I added a new parameter to define the `mode` to avoid changing it on wrong places.