### PR TITLE
ENG-2993: updating redux store after creating a new group

### DIFF
--- a/src/state/groups/actions.js
+++ b/src/state/groups/actions.js
@@ -142,7 +142,7 @@ export const sendPutGroup = groupData => dispatch => (
   })
 );
 
-export const sendPostGroup = groupData => dispatch => (
+export const sendPostGroup = groupData => (dispatch, getState) => (
   new Promise((resolve) => {
     postGroup(groupData).then((response) => {
       response.json().then((data) => {
@@ -151,6 +151,9 @@ export const sendPostGroup = groupData => dispatch => (
             { id: 'app.created', values: { type: 'group', code: groupData.code } },
             TOAST_SUCCESS,
           ));
+          // update store with new group
+          const { groups } = getState();
+          dispatch(setGroups([...groups.groupEntries, groupData]));
           history.push(ROUTE_GROUP_LIST);
           resolve();
         } else {

--- a/test/state/groups/actions.test.js
+++ b/test/state/groups/actions.test.js
@@ -123,6 +123,7 @@ const INITIAL_STATE = {
     map: {},
     selected: {},
     total: 0,
+    groupEntries: [],
   },
 };
 
@@ -220,6 +221,12 @@ describe('state/groups/actions', () => {
     it('when postGroup succeeds, should call router', (done) => {
       postGroup.mockReturnValueOnce(new Promise(resolve => resolve(POST_GROUP_PROMISE)));
       store.dispatch(sendPostGroup(BODY_OK)).then(() => {
+        const actions = store.getActions();
+        expect(actions).toHaveLength(2);
+        expect(actions[0]).toHaveProperty('type', ADD_TOAST);
+        expect(actions[0].payload).toHaveProperty('type', 'success');
+        expect(actions[1]).toHaveProperty('type', SET_GROUPS);
+        expect(actions[1].payload).toHaveProperty('groups', [BODY_OK]);
         expect(postGroup).toHaveBeenCalled();
         expect(history.push).toHaveBeenCalledWith(ROUTE_GROUP_LIST);
         done();


### PR DESCRIPTION
After creation of new group is succeed, immediately update the redux store with the new entry so it gets reflected on other parts of the system without the need of a refetch