### PR TITLE
ENG-3222 Show content scheduler in cms menu if plugin is installed

### DIFF
--- a/src/api/system.js
+++ b/src/api/system.js
@@ -1,0 +1,9 @@
+import { makeRequest, METHODS } from '@entando/apimanager';
+
+// eslint-disable-next-line import/prefer-default-export
+export const getSystemReport = () => makeRequest({
+  uri: '/api/system/report',
+  method: METHODS.GET,
+  mockResponse: {},
+  useAuthentication: true,
+});

--- a/src/state/rootReducer.js
+++ b/src/state/rootReducer.js
@@ -46,6 +46,7 @@ import contentSettings from 'state/content-settings/reducer';
 import contents from 'state/contents/reducer';
 import versioning from 'state/versioning/reducer';
 import tableColumns from 'state/table-columns/reducer';
+import system from 'state/system/reducer';
 
 import entandoApps from 'entando-apps';
 import hub from 'state/component-repository/hub/reducer';
@@ -103,6 +104,7 @@ const reducerDef = {
   versioning,
   tableColumns,
   hub,
+  system,
 };
 
 // app root reducer

--- a/src/state/system/actions.js
+++ b/src/state/system/actions.js
@@ -1,0 +1,23 @@
+import { addToast, TOAST_ERROR } from '@entando/messages';
+
+import { SET_SYSTEM_REPORT } from 'state/system/types';
+import { getSystemReport } from 'api/system';
+
+export const setSystemReport = systemReport => ({
+  type: SET_SYSTEM_REPORT,
+  payload: systemReport,
+});
+
+export const fetchSystemReport = () => async (dispatch) => {
+  try {
+    const response = await getSystemReport();
+    const json = await response.json();
+    if (response.ok) {
+      dispatch(setSystemReport(json.payload));
+    } else {
+      json.errors.forEach(err => dispatch(addToast(err.message, TOAST_ERROR)));
+    }
+  } catch (e) {
+    // do nothing...
+  }
+};

--- a/src/state/system/reducer.js
+++ b/src/state/system/reducer.js
@@ -1,0 +1,16 @@
+import { combineReducers } from 'redux';
+
+import { SET_SYSTEM_REPORT } from 'state/system/types';
+
+const report = (state = {}, action = {}) => {
+  switch (action.type) {
+    case SET_SYSTEM_REPORT:
+      return action.payload;
+    default:
+      return state;
+  }
+};
+
+export default combineReducers({
+  report,
+});

--- a/src/state/system/selectors.js
+++ b/src/state/system/selectors.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const getSystemReport = state => state.system.report;

--- a/src/state/system/types.js
+++ b/src/state/system/types.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const SET_SYSTEM_REPORT = 'system/set-system-report';

--- a/test/api/system.test.js
+++ b/test/api/system.test.js
@@ -1,0 +1,26 @@
+import { makeRequest, METHODS } from '@entando/apimanager';
+
+import { getSystemReport } from 'api/system';
+
+jest.mock('@entando/apimanager', () => ({
+  makeRequest: jest.fn(() => new Promise(resolve => resolve({}))),
+  METHODS: { GET: 'GET' },
+}));
+
+describe('api/system', () => {
+  describe('getSystemReport', () => {
+    it('should return a promise', () => {
+      expect(getSystemReport()).toBeInstanceOf(Promise);
+    });
+
+    it('should make a request with the correct parameters', () => {
+      getSystemReport();
+      expect(makeRequest).toHaveBeenCalledWith({
+        uri: '/api/system/report',
+        method: METHODS.GET,
+        mockResponse: {},
+        useAuthentication: true,
+      });
+    });
+  });
+});

--- a/test/state/system/actions.test.js
+++ b/test/state/system/actions.test.js
@@ -1,0 +1,73 @@
+import thunk from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
+import { ADD_TOAST, TOAST_ERROR } from '@entando/messages';
+
+import { setSystemReport, fetchSystemReport } from 'state/system/actions';
+import { getSystemReport } from 'api/system';
+import { mockApi } from 'test/testUtils';
+
+jest.mock('api/system', () => ({
+  getSystemReport: jest.fn(),
+}));
+
+const middlewares = [thunk];
+const createMockStore = configureMockStore(middlewares);
+
+const MOCK_ERROR_MESSAGE = 'Test error message';
+const MOCK_ADD_TOAST_ERROR_ACTION = {
+  type: ADD_TOAST,
+  payload: { message: MOCK_ERROR_MESSAGE, type: TOAST_ERROR },
+};
+
+describe('state/system/actions', () => {
+  const testReport = { testKey: 'testVal' };
+
+  let store;
+
+  const dispatch = action => store.dispatch(action);
+
+  const getActions = () => store.getActions();
+
+  beforeEach(() => {
+    store = createMockStore({});
+  });
+
+  describe('setSystemReport', () => {
+    it('should create the correct action object', () => {
+      expect(setSystemReport(testReport)).toEqual({
+        type: 'system/set-system-report',
+        payload: testReport,
+      });
+    });
+  });
+
+  describe('fetchSystemReport', () => {
+    it('should set system report on success', (done) => {
+      getSystemReport.mockImplementationOnce(mockApi({ payload: testReport }));
+
+      const expectedActions = [
+        { type: 'system/set-system-report', payload: testReport },
+      ];
+
+      dispatch(fetchSystemReport()).then(() => {
+        const actions = getActions();
+        expect(actions).toEqual(expectedActions);
+        done();
+      }).catch(done.fail);
+    });
+
+    it('should dispatch the correct actions on error', (done) => {
+      getSystemReport.mockImplementationOnce(mockApi({
+        errors: [{ message: MOCK_ERROR_MESSAGE }],
+      }));
+
+      const expectedActions = [MOCK_ADD_TOAST_ERROR_ACTION];
+
+      dispatch(fetchSystemReport()).then(() => {
+        const actions = getActions();
+        expect(actions).toEqual(expectedActions);
+        done();
+      }).catch(done.fail);
+    });
+  });
+});

--- a/test/state/system/reducer.test.js
+++ b/test/state/system/reducer.test.js
@@ -1,0 +1,19 @@
+import reducer from 'state/system/reducer';
+import { SET_SYSTEM_REPORT } from 'state/system/types';
+
+describe('state/system/reducer', () => {
+  const initialState = {
+    report: {},
+  };
+
+  it('should return the correct state when action is SET_SYSTEM_REPORT', () => {
+    const testReport = { testKey: 'testVal' };
+    const state = reducer(initialState, {
+      type: SET_SYSTEM_REPORT, payload: testReport,
+    });
+    expect(state).toEqual({
+      ...initialState,
+      report: testReport,
+    });
+  });
+});

--- a/test/state/system/selectors.test.js
+++ b/test/state/system/selectors.test.js
@@ -1,0 +1,18 @@
+import { getSystemReport } from 'state/system/selectors';
+
+describe('state/system/selectors', () => {
+  const state = {
+    system: {
+      report: {
+        testKey: 'testVal',
+      },
+    },
+  };
+
+  describe('getSystemReport', () => {
+    it('should return the correct object from state', () => {
+      const result = getSystemReport(state);
+      expect(result).toBe(state.system.report);
+    });
+  });
+});


### PR DESCRIPTION
* Adds content scheduler to cms menu and shown based on scheduler plugin existence
* Adds 'system' state-related files and api