### PR TITLE
ENG-3437 Fixed admin-console redirect URL

### DIFF
--- a/src/ui/contents/ContentsContainer.js
+++ b/src/ui/contents/ContentsContainer.js
@@ -153,7 +153,7 @@ export const mapDispatchToProps = (dispatch, { intl, history }) => ({
     dispatch(setWorkMode(WORK_MODE_ADD));
     dispatch(setCurrentStatusShow('all'));
     dispatch(setNewContentsType(contentType));
-    const newRoute = adminConsoleUrl(`do/jacms/Content/entryContent.action?contentOnSessionMarker=${contentType.typeCode}_newContent`);
+    const newRoute = adminConsoleUrl(`do/jacms/Content/createNew.action?contentTypeCode=${contentType.typeCode}`);
     window.location.href = newRoute;
   },
   onClickJoinCategories: (contents) => {

--- a/src/ui/contents/list-card/ContentListCardContainer.js
+++ b/src/ui/contents/list-card/ContentListCardContainer.js
@@ -34,7 +34,7 @@ const mapDispatchToProps = dispatch => ({
   onClickAddContent: (contentType) => {
     dispatch(setWorkMode(WORK_MODE_ADD));
     dispatch(setNewContentsType(contentType));
-    const newRoute = adminConsoleUrl(`do/jacms/Content/entryContent.action?contentOnSessionMarker=${contentType.typeCode}_newContent`);
+    const newRoute = adminConsoleUrl(`do/jacms/Content/createNew.action?contentTypeCode=${contentType.typeCode}`);
     window.location.href = newRoute;
   },
 });

--- a/src/ui/widget-forms/publish-single-content-config/SingleContentConfigContainer.js
+++ b/src/ui/widget-forms/publish-single-content-config/SingleContentConfigContainer.js
@@ -122,7 +122,7 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
       dispatch(setWorkMode(WORK_MODE_ADD));
       dispatch(setCurrentStatusShow('all'));
       dispatch(setNewContentsType(contentType));
-      const newRoute = adminConsoleUrl(`do/jacms/Content/entryContent.action?contentOnSessionMarker=${contentType.typeCode}_newContent`);
+      const newRoute = adminConsoleUrl(`do/jacms/Content/createNew.action?contentTypeCode=${contentType.typeCode}`);
       window.location.href = newRoute;
     },
   };


### PR DESCRIPTION
Correct URL for creating a content is `do/jacms/Content/createNew.action?contentTypeCode=${contentType.typeCode}`.
When the Java app is called at this URL it sets the context and then redirects to `do/jacms/Content/entryContent.action?contentOnSessionMarker=${contentType.typeCode}_newContent`.