### PR TITLE
ENG-3465 add disabled actions due to groups

### DIFF
--- a/src/api/permissions.js
+++ b/src/api/permissions.js
@@ -20,7 +20,7 @@ export const getMyGroupPermissions = () => (
     method: METHODS.GET,
     mockResponse: MY_PERMISSIONS_PAYLOAD_OK,
     useAuthentication: true,
-    useCredentials: true,
+    // useCredentials: true,
   })
 );
 

--- a/src/state/groups/actions.js
+++ b/src/state/groups/actions.js
@@ -19,11 +19,19 @@ import {
   REMOVE_GROUP,
   SET_GROUPS_TOTAL,
   SET_GROUP_ENTRIES,
+  SET_MY_GROUPS,
 } from 'state/groups/types';
 import { history, ROUTE_GROUP_LIST } from 'app-init/router';
 
 export const setGroups = groups => ({
   type: SET_GROUPS,
+  payload: {
+    groups,
+  },
+});
+
+export const setMyGroups = groups => ({
+  type: SET_MY_GROUPS,
   payload: {
     groups,
   },
@@ -75,7 +83,7 @@ export const fetchMyGroups = ({ sort } = {}) => dispatch => new Promise((resolve
         if (sort) {
           groups.sort((a, b) => a[sort].localeCompare(b[sort]));
         }
-        dispatch(setGroups(groups));
+        dispatch(setMyGroups(groups));
         dispatch(toggleLoading('groups'));
         resolve();
       } else {
@@ -153,7 +161,7 @@ export const sendPostGroup = groupData => (dispatch, getState) => (
           ));
           // update store with new group
           const { groups } = getState();
-          dispatch(setGroupEntries([...groups.groupEntries, groupData]));
+          dispatch(setGroups([...groups.groupEntries, groupData]));
           history.push(ROUTE_GROUP_LIST);
           resolve();
         } else {

--- a/src/state/groups/actions.js
+++ b/src/state/groups/actions.js
@@ -84,6 +84,7 @@ export const fetchMyGroups = ({ sort } = {}) => dispatch => new Promise((resolve
           groups.sort((a, b) => a[sort].localeCompare(b[sort]));
         }
         dispatch(setMyGroups(groups));
+        dispatch(setGroups(groups));
         dispatch(toggleLoading('groups'));
         resolve();
       } else {

--- a/src/state/groups/actions.js
+++ b/src/state/groups/actions.js
@@ -153,7 +153,7 @@ export const sendPostGroup = groupData => (dispatch, getState) => (
           ));
           // update store with new group
           const { groups } = getState();
-          dispatch(setGroups([...groups.groupEntries, groupData]));
+          dispatch(setGroupEntries([...groups.groupEntries, groupData]));
           history.push(ROUTE_GROUP_LIST);
           resolve();
         } else {

--- a/src/state/groups/reducer.js
+++ b/src/state/groups/reducer.js
@@ -6,6 +6,7 @@ import {
   SET_REFERENCES,
   REMOVE_GROUP,
   SET_GROUP_ENTRIES,
+  SET_MY_GROUPS,
 } from 'state/groups/types';
 
 export const toMap = array => array.reduce((acc, group) => {
@@ -23,6 +24,15 @@ export const list = (state = [], action = {}) => {
     case REMOVE_GROUP: {
       const { groupCode } = action.payload;
       return state.filter(group => group !== groupCode);
+    }
+    default: return state;
+  }
+};
+
+export const myGroupsList = (state = [], action = {}) => {
+  switch (action.type) {
+    case SET_MY_GROUPS: {
+      return toIdList(action.payload.groups);
     }
     default: return state;
   }
@@ -100,4 +110,5 @@ export default combineReducers({
   selected,
   total,
   groupEntries,
+  myGroupsList,
 });

--- a/src/state/groups/selectors.js
+++ b/src/state/groups/selectors.js
@@ -16,6 +16,12 @@ export const getGroupsIdList =
     groups => (groups.list || []),
   );
 
+export const getMyGroupsList =
+  createSelector(
+    getGroups,
+    groups => (groups.myGroupsList || []),
+  );
+
 export const getGroupsMap =
   createSelector(
     getGroups,
@@ -64,10 +70,10 @@ export const getSelectedGroupResourceReferences =
   );
 
 export const getSelectedGroupContentReferences =
-    createSelector(
-      getReferenceMap,
-      refMap => (refMap[CONTENT_REFERENCE_KEY] || []),
-    );
+  createSelector(
+    getReferenceMap,
+    refMap => (refMap[CONTENT_REFERENCE_KEY] || []),
+  );
 
 export const getSelectedGroupUserReferences =
   createSelector(
@@ -82,13 +88,13 @@ export const getSelectedGroupWidgetTypeReferences =
   );
 
 export const getWidgetTypeReferences =
-    createSelector(
-      getSelectedGroupWidgetTypeReferences, getLocale,
-      (widgets, locale) => (widgets ? widgets.map(widget => ({
-        code: widget.code,
-        title: widget.titles[locale],
-      })) : []),
-    );
+  createSelector(
+    getSelectedGroupWidgetTypeReferences, getLocale,
+    (widgets, locale) => (widgets ? widgets.map(widget => ({
+      code: widget.code,
+      title: widget.titles[locale],
+    })) : []),
+  );
 
 export const getSelectedGroupPageReferences =
   createSelector(

--- a/src/state/groups/types.js
+++ b/src/state/groups/types.js
@@ -4,3 +4,4 @@ export const SET_SELECTED_GROUP = 'groups/set-selected-group';
 export const SET_REFERENCES = 'groups/set-references';
 export const SET_GROUPS_TOTAL = 'groups/set-groups-total';
 export const SET_GROUP_ENTRIES = 'groups/set-group-entries';
+export const SET_MY_GROUPS = 'groups/set-my-groups';

--- a/src/ui/pages/common/PageForm.js
+++ b/src/ui/pages/common/PageForm.js
@@ -46,6 +46,22 @@ export class PageFormBody extends Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    const { myGroups: prevMyGroups, pageOwnerGroup: prevPageOwnerGroup } = prevProps;
+    const {
+      enableGroupAccessControl, myGroups, redirectToPageList, pageOwnerGroup,
+    } = this.props;
+
+    if (enableGroupAccessControl) {
+      if (myGroups != null && pageOwnerGroup && (prevMyGroups == null || !prevPageOwnerGroup)) {
+        const redirectDueToLackOfGroupAccess = !myGroups.includes(pageOwnerGroup);
+        if (redirectDueToLackOfGroupAccess) {
+          redirectToPageList();
+        }
+      }
+    }
+  }
+
   render() {
     const {
       intl, handleSubmit, invalid, submitting, groups, allGroups, pageTemplates,
@@ -244,7 +260,7 @@ export class PageFormBody extends Component {
                       >
                         {type}
                       </option>
-                  ))}
+                    ))}
                   </Field>
                 </Col>
                 <label htmlFor="seo" className="col-xs-2 col-xs-offset-2 control-label">
@@ -270,7 +286,7 @@ export class PageFormBody extends Component {
                       >
                         {type}
                       </option>
-                  ))}
+                    ))}
                   </Field>
                 </Col>
               </FormGroup>
@@ -325,7 +341,7 @@ export class PageFormBody extends Component {
                 <FormLabel labelId="pages.pageForm.pagePlacement" required />
               </label>
               <Col xs={10}>
-                { parentPageComponent }
+                {parentPageComponent}
               </Col>
             </FormGroup>
 
@@ -368,7 +384,7 @@ export class PageFormBody extends Component {
                     onSaveClick(
                       { ...values, appTourProgress },
                       ACTION_SAVE_AND_CONFIGURE,
-                  ))}
+                    ))}
                 >
                   <FormattedMessage id="pages.pageForm.saveAndConfigure" />
 
@@ -388,7 +404,7 @@ export class PageFormBody extends Component {
               </div>
             </Col>
           </Row>
-        ) }
+        )}
       </form>
     );
   }
@@ -434,6 +450,10 @@ PageFormBody.propTypes = {
   onChangeOwnerGroup: PropTypes.func,
   readOnly: PropTypes.bool,
   stayOnSave: PropTypes.bool,
+  enableGroupAccessControl: PropTypes.bool,
+  myGroups: PropTypes.arrayOf(PropTypes.string),
+  redirectToPageList: PropTypes.func,
+  pageOwnerGroup: PropTypes.string,
 };
 
 PageFormBody.defaultProps = {
@@ -453,6 +473,10 @@ PageFormBody.defaultProps = {
   onChangeOwnerGroup: () => {},
   readOnly: false,
   stayOnSave: false,
+  enableGroupAccessControl: false,
+  myGroups: null,
+  redirectToPageList: () => {},
+  pageOwnerGroup: '',
 };
 
 const PageForm = reduxForm({

--- a/src/ui/pages/common/PageTree.js
+++ b/src/ui/pages/common/PageTree.js
@@ -89,7 +89,7 @@ class PageTree extends Component {
               <TreeNodeExpandedIcon expanded={page.expanded} />
               <TreeNodeFolderIcon empty={page.isEmpty} />
               <span className="PageTree__page-name">
-                { page.title }
+                {page.title}
               </span>
               <RowSpinner loading={!!page.loading} />
             </span>
@@ -165,6 +165,7 @@ class PageTree extends Component {
         onClickPreview={this.props.onClickPreview}
         locale={this.props.locale}
         domain={this.props.domain}
+        myGroupIds={this.props.myGroupIds}
       />
     );
   }
@@ -256,6 +257,7 @@ PageTree.propTypes = {
   locale: PropTypes.string.isRequired,
   onSetColumnOrder: PropTypes.func,
   columnOrder: PropTypes.arrayOf(PropTypes.string),
+  myGroupIds: PropTypes.arrayOf(PropTypes.string),
 };
 
 PageTree.defaultProps = {
@@ -267,6 +269,7 @@ PageTree.defaultProps = {
   onCollapseAll: () => {},
   onSetColumnOrder: () => {},
   columnOrder: ['title', 'status', 'displayedInMenu'],
+  myGroupIds: [],
 };
 
 export default PageTree;

--- a/src/ui/pages/common/PageTreeActionMenu.js
+++ b/src/ui/pages/common/PageTreeActionMenu.js
@@ -28,8 +28,10 @@ class PageTreeActionMenu extends Component {
     const {
       page, onClickAdd, onClickEdit, onClickConfigure, onClickDetails,
       onClickClone, onClickDelete, onClickPublish, onClickUnpublish,
-      onClickViewPublishedPage, onClickPreview,
+      onClickViewPublishedPage, onClickPreview, myGroupIds,
     } = this.props;
+
+    const disableDueToLackOfGroupAccess = !myGroupIds.includes(page.ownerGroup);
 
     let disabled = false;
     if (!page.isEmpty && page.status === PAGE_STATUS_PUBLISHED) {
@@ -38,23 +40,26 @@ class PageTreeActionMenu extends Component {
     if (page.expanded) {
       disabled = page.hasPublishedChildren;
     }
+
+    const disablePublishAction = (page.status === PAGE_STATUS_UNPUBLISHED &&
+      page.parentStatus === PAGE_STATUS_UNPUBLISHED)
+      || disableDueToLackOfGroupAccess;
     const changePublishStatus = page.status === PAGE_STATUS_PUBLISHED ?
       (
         <MenuItem
-          disabled={disabled}
+          disabled={disabled || disableDueToLackOfGroupAccess}
           className="PageTreeActionMenuButton__menu-item-unpublish"
-          onSelect={this.handleClick(onClickUnpublish)}
+          onSelect={!(disabled || disableDueToLackOfGroupAccess)
+            ? this.handleClick(onClickUnpublish) : null}
         >
           <FormattedMessage id="app.unpublish" />
-        </MenuItem>
+        </MenuItem >
       ) :
       (
         <MenuItem
-          disabled={
-            page.status === PAGE_STATUS_UNPUBLISHED && page.parentStatus === PAGE_STATUS_UNPUBLISHED
-          }
+          disabled={disablePublishAction}
           className="PageTreeActionMenuButton__menu-item-publish"
-          onSelect={this.handleClick(onClickPublish)}
+          onSelect={!disablePublishAction ? this.handleClick(onClickPublish) : null}
         >
           <FormattedMessage id="app.publish" />
         </MenuItem>
@@ -79,12 +84,13 @@ class PageTreeActionMenu extends Component {
         </MenuItem>
       );
 
+    const disableDelete = !page.isEmpty || page.status === PAGE_STATUS_PUBLISHED ||
+      page.status === PAGE_STATUS_DRAFT || disableDueToLackOfGroupAccess;
     const renderDeleteItem = () => (
       <MenuItem
-        disabled={!page.isEmpty || page.status === PAGE_STATUS_PUBLISHED ||
-          page.status === PAGE_STATUS_DRAFT}
+        disabled={disableDelete}
         className="PageTreeActionMenuButton__menu-item-delete"
-        onSelect={this.handleClick(onClickDelete)}
+        onSelect={!disableDelete ? this.handleClick(onClickDelete) : null}
       >
         <FormattedMessage id="app.delete" />
       </MenuItem>
@@ -102,7 +108,8 @@ class PageTreeActionMenu extends Component {
           {onClickEdit && (
             <MenuItem
               className="PageTreeActionMenuButton__menu-item-edit"
-              onSelect={this.handleClick(onClickEdit)}
+              onSelect={!disableDueToLackOfGroupAccess ? this.handleClick(onClickEdit) : null}
+              disabled={disableDueToLackOfGroupAccess}
             >
               <FormattedMessage id="app.edit" />
             </MenuItem>
@@ -110,14 +117,16 @@ class PageTreeActionMenu extends Component {
           {onClickConfigure && (
             <MenuItem
               className="PageTreeActionMenuButton__menu-item-configure"
-              onSelect={this.handleClick(onClickConfigure)}
+              onSelect={!disableDueToLackOfGroupAccess ? this.handleClick(onClickConfigure) : null}
+              disabled={disableDueToLackOfGroupAccess}
             >
               <FormattedMessage id="app.design" />
             </MenuItem>
           )}
           <MenuItem
             className="PageTreeActionMenuButton__menu-item-clone"
-            onSelect={this.handleClick(onClickClone)}
+            onSelect={!disableDueToLackOfGroupAccess ? this.handleClick(onClickClone) : null}
+            disabled={disableDueToLackOfGroupAccess}
           >
             <FormattedMessage id="app.clone" />
           </MenuItem>
@@ -152,6 +161,7 @@ PageTreeActionMenu.propTypes = {
     hasPublishedChildren: PropTypes.bool,
     code: PropTypes.string,
     parentStatus: PropTypes.string,
+    ownerGroup: PropTypes.string,
   }).isRequired,
   onClickAdd: PropTypes.func,
   onClickEdit: PropTypes.func,
@@ -165,6 +175,7 @@ PageTreeActionMenu.propTypes = {
   onClickPreview: PropTypes.func,
   domain: PropTypes.string.isRequired,
   locale: PropTypes.string.isRequired,
+  myGroupIds: PropTypes.arrayOf(PropTypes.string),
 };
 
 PageTreeActionMenu.defaultProps = {
@@ -178,6 +189,7 @@ PageTreeActionMenu.defaultProps = {
   onClickUnpublish: null,
   onClickViewPublishedPage: null,
   onClickPreview: null,
+  myGroupIds: [],
 };
 
 export default PageTreeActionMenu;

--- a/src/ui/pages/common/PageTreeContainer.js
+++ b/src/ui/pages/common/PageTreeContainer.js
@@ -34,6 +34,7 @@ import { PAGE_INIT_VALUES } from 'ui/pages/common/const';
 import { setAppTourLastStep } from 'state/app-tour/actions';
 import { getDomain } from '@entando/apimanager';
 import { PREVIEW_NAMESPACE } from 'ui/pages/config/const';
+import { getGroupsIdList } from 'state/groups/selectors';
 
 export const mapStateToProps = state => ({
   locale: getLocale(state),
@@ -45,6 +46,7 @@ export const mapStateToProps = state => ({
   domain: getDomain(state),
   columnOrder: getColumnOrder(state, 'pageList'),
   pageSearchColumnOrder: getColumnOrder(state, 'pageSearch'),
+  myGroupIds: getGroupsIdList(state),
 });
 
 export const mapDispatchToProps = (dispatch, ownProps) => ({

--- a/src/ui/pages/common/PageTreeContainer.js
+++ b/src/ui/pages/common/PageTreeContainer.js
@@ -34,7 +34,7 @@ import { PAGE_INIT_VALUES } from 'ui/pages/common/const';
 import { setAppTourLastStep } from 'state/app-tour/actions';
 import { getDomain } from '@entando/apimanager';
 import { PREVIEW_NAMESPACE } from 'ui/pages/config/const';
-import { getGroupsIdList } from 'state/groups/selectors';
+import { getMyGroupsList } from 'state/groups/selectors';
 
 export const mapStateToProps = state => ({
   locale: getLocale(state),
@@ -46,7 +46,7 @@ export const mapStateToProps = state => ({
   domain: getDomain(state),
   columnOrder: getColumnOrder(state, 'pageList'),
   pageSearchColumnOrder: getColumnOrder(state, 'pageSearch'),
-  myGroupIds: getGroupsIdList(state),
+  myGroupIds: getMyGroupsList(state),
 });
 
 export const mapDispatchToProps = (dispatch, ownProps) => ({

--- a/src/ui/pages/config/ContentPages.js
+++ b/src/ui/pages/config/ContentPages.js
@@ -105,7 +105,7 @@ class ContentPages extends Component {
   render() {
     const {
       loading, onExpandPage, pages, intl, searchPages,
-      onClear, loadOnPageSelect, onLoadPage,
+      onClear, loadOnPageSelect, onLoadPage, myGroupIds,
     } = this.props;
     const { expanded } = this.state;
 
@@ -178,6 +178,7 @@ class ContentPages extends Component {
               onExpandPage={onExpandPage}
               onRowClick={this.handlePageSelect}
               onClickConfigure={!loadOnPageSelect ? onLoadPage : null}
+              myGroupIds={myGroupIds}
             />
           )}
         </Spinner>
@@ -204,6 +205,7 @@ ContentPages.propTypes = {
   loadOnPageSelect: PropTypes.bool,
   onLoadPage: PropTypes.func,
   onSearchPageChange: PropTypes.func.isRequired,
+  myGroupIds: PropTypes.arrayOf(PropTypes.string),
 };
 ContentPages.defaultProps = {
   onWillMount: () => {},
@@ -218,6 +220,7 @@ ContentPages.defaultProps = {
   selectedPage: {},
   loadOnPageSelect: true,
   onLoadPage: () => {},
+  myGroupIds: [],
 };
 
 export default injectIntl(ContentPages);

--- a/src/ui/pages/config/ContentPagesContainer.js
+++ b/src/ui/pages/config/ContentPagesContainer.js
@@ -26,7 +26,7 @@ import { getUserPreferences } from 'state/user-preferences/selectors';
 import { history, ROUTE_PAGE_CONFIG } from 'app-init/router';
 import { getDomain } from '@entando/apimanager';
 import { PREVIEW_NAMESPACE } from 'ui/pages/config/const';
-import { getGroupsIdList } from 'state/groups/selectors';
+import { getMyGroupsList } from 'state/groups/selectors';
 
 export const mapStateToProps = state => ({
   loading: getLoading(state).pageTree,
@@ -39,7 +39,7 @@ export const mapStateToProps = state => ({
   totalItems: getTotalItems(state),
   pageSize: getPageSize(state),
   domain: getDomain(state),
-  myGroupIds: getGroupsIdList(state),
+  myGroupIds: getMyGroupsList(state),
 });
 
 export const mapDispatchToProps = dispatch => ({

--- a/src/ui/pages/config/ContentPagesContainer.js
+++ b/src/ui/pages/config/ContentPagesContainer.js
@@ -26,6 +26,7 @@ import { getUserPreferences } from 'state/user-preferences/selectors';
 import { history, ROUTE_PAGE_CONFIG } from 'app-init/router';
 import { getDomain } from '@entando/apimanager';
 import { PREVIEW_NAMESPACE } from 'ui/pages/config/const';
+import { getGroupsIdList } from 'state/groups/selectors';
 
 export const mapStateToProps = state => ({
   loading: getLoading(state).pageTree,
@@ -38,6 +39,7 @@ export const mapStateToProps = state => ({
   totalItems: getTotalItems(state),
   pageSize: getPageSize(state),
   domain: getDomain(state),
+  myGroupIds: getGroupsIdList(state),
 });
 
 export const mapDispatchToProps = dispatch => ({

--- a/src/ui/pages/edit/PagesEditFormContainer.js
+++ b/src/ui/pages/edit/PagesEditFormContainer.js
@@ -4,7 +4,7 @@ import { routeConverter } from '@entando/utils';
 
 import PageForm from 'ui/pages/common/PageForm';
 import { getActiveLanguages } from 'state/languages/selectors';
-import { getGroupEntries, getGroupsList } from 'state/groups/selectors';
+import { getGroupEntries, getGroupsList, getMyGroupsList } from 'state/groups/selectors';
 import { getPageTemplatesList } from 'state/page-templates/selectors';
 import { getCharsets, getContentTypes, getPageTreePages } from 'state/pages/selectors';
 import { ACTION_SAVE, ACTION_SAVE_AND_CONFIGURE, SEO_ENABLED } from 'state/pages/const';
@@ -14,12 +14,14 @@ import { fetchPageTemplates } from 'state/page-templates/actions';
 import { history, ROUTE_PAGE_TREE, ROUTE_PAGE_CONFIG } from 'app-init/router';
 import { fetchLanguages } from 'state/languages/actions';
 import { setVisibleModal } from 'state/modal/actions';
+import { formValueSelector } from 'redux-form';
 
 export const FORM_ID = 'pageEdit';
 
 export const mapStateToProps = (state, { match: { params } }) => ({
   languages: getActiveLanguages(state),
   groups: getGroupsList(state),
+  myGroups: getMyGroupsList(state),
   allGroups: getGroupEntries(state),
   pageTemplates: getPageTemplatesList(state),
   pages: getPageTreePages(state),
@@ -30,6 +32,8 @@ export const mapStateToProps = (state, { match: { params } }) => ({
   pageCode: params.pageCode,
   form: FORM_ID,
   keepDirtyOnReinitialize: true,
+  enableGroupAccessControl: true,
+  pageOwnerGroup: formValueSelector(FORM_ID)(state, 'ownerGroup'),
 });
 
 
@@ -59,6 +63,7 @@ export const mapDispatchToProps = (dispatch, ownProps) => ({
     dispatch(fetchPageForm(pageCode));
   },
   onFindTemplateClick: () => dispatch(setVisibleModal('FindTemplateModal')),
+  redirectToPageList: () => history.push(ROUTE_PAGE_TREE),
 });
 
 

--- a/test/state/groups/actions.test.js
+++ b/test/state/groups/actions.test.js
@@ -15,6 +15,7 @@ import {
   fetchReferences,
   removeGroupSync,
   fetchAllGroupEntries,
+  setMyGroups,
 } from 'state/groups/actions';
 import {
   putGroup,
@@ -35,6 +36,7 @@ import {
   SET_REFERENCES,
   REMOVE_GROUP,
   SET_GROUP_ENTRIES,
+  SET_MY_GROUPS,
 } from 'state/groups/types';
 import { TOGGLE_LOADING } from 'state/loading/types';
 import { SET_PAGE } from 'state/pagination/types';
@@ -124,6 +126,7 @@ const INITIAL_STATE = {
     selected: {},
     total: 0,
     groupEntries: [],
+    myGroupsList: [],
   },
 };
 
@@ -138,6 +141,13 @@ describe('state/groups/actions', () => {
     it('test setGroups action sets the correct type', () => {
       const action = setGroups(LIST_GROUPS_OK);
       expect(action).toHaveProperty('type', SET_GROUPS);
+    });
+  });
+
+  describe('setMyGroups', () => {
+    it('test setMyGroups action sets the correct type', () => {
+      const action = setMyGroups(LIST_GROUPS_OK);
+      expect(action).toHaveProperty('type', SET_MY_GROUPS);
     });
   });
 
@@ -162,7 +172,7 @@ describe('state/groups/actions', () => {
         const actions = store.getActions();
         expect(actions).toHaveLength(3);
         expect(actions[0].type).toEqual(TOGGLE_LOADING);
-        expect(actions[1].type).toEqual(SET_GROUPS);
+        expect(actions[1].type).toEqual(SET_MY_GROUPS);
         expect(actions[2].type).toEqual(TOGGLE_LOADING);
         done();
       }).catch(done.fail);
@@ -225,7 +235,7 @@ describe('state/groups/actions', () => {
         expect(actions).toHaveLength(2);
         expect(actions[0]).toHaveProperty('type', ADD_TOAST);
         expect(actions[0].payload).toHaveProperty('type', 'success');
-        expect(actions[1]).toHaveProperty('type', SET_GROUP_ENTRIES);
+        expect(actions[1]).toHaveProperty('type', SET_GROUPS);
         expect(actions[1].payload).toHaveProperty('groups', [BODY_OK]);
         expect(postGroup).toHaveBeenCalled();
         expect(history.push).toHaveBeenCalledWith(ROUTE_GROUP_LIST);

--- a/test/state/groups/actions.test.js
+++ b/test/state/groups/actions.test.js
@@ -170,10 +170,11 @@ describe('state/groups/actions', () => {
     it('fetchMyGroupscalls setGroups and setPage actions', (done) => {
       store.dispatch(fetchMyGroups()).then(() => {
         const actions = store.getActions();
-        expect(actions).toHaveLength(3);
+        expect(actions).toHaveLength(4);
         expect(actions[0].type).toEqual(TOGGLE_LOADING);
         expect(actions[1].type).toEqual(SET_MY_GROUPS);
-        expect(actions[2].type).toEqual(TOGGLE_LOADING);
+        expect(actions[2].type).toEqual(SET_GROUPS);
+        expect(actions[3].type).toEqual(TOGGLE_LOADING);
         done();
       }).catch(done.fail);
     });

--- a/test/state/groups/actions.test.js
+++ b/test/state/groups/actions.test.js
@@ -102,14 +102,14 @@ const GET_REFERENCES_PROMISE = {
 
 
 const MOCK_RETURN_PROMISE_ERROR =
-  {
-    ok: false,
-    json: () => new Promise(err => err({
-      errors: [
-        { message: 'what went wrong' },
-      ],
-    })),
-  };
+{
+  ok: false,
+  json: () => new Promise(err => err({
+    errors: [
+      { message: 'what went wrong' },
+    ],
+  })),
+};
 
 getGroups.mockReturnValue(new Promise(resolve => resolve(GET_GROUPS_PROMISE)));
 getMyGroups.mockReturnValue(new Promise(resolve => resolve(GET_GROUPS_PROMISE)));
@@ -225,7 +225,7 @@ describe('state/groups/actions', () => {
         expect(actions).toHaveLength(2);
         expect(actions[0]).toHaveProperty('type', ADD_TOAST);
         expect(actions[0].payload).toHaveProperty('type', 'success');
-        expect(actions[1]).toHaveProperty('type', SET_GROUPS);
+        expect(actions[1]).toHaveProperty('type', SET_GROUP_ENTRIES);
         expect(actions[1].payload).toHaveProperty('groups', [BODY_OK]);
         expect(postGroup).toHaveBeenCalled();
         expect(history.push).toHaveBeenCalledWith(ROUTE_GROUP_LIST);

--- a/test/state/groups/reducer.test.js
+++ b/test/state/groups/reducer.test.js
@@ -6,11 +6,13 @@ import {
   setSelectedGroup,
   setReferences,
   removeGroupSync,
+  setMyGroups,
 } from 'state/groups/actions';
 
 import {
   getGroupsList,
   getSelectedGroup,
+  getMyGroupsList,
 } from 'state/groups/selectors';
 
 import {
@@ -45,6 +47,17 @@ describe('state/groups/reducer', () => {
 
     it('should define the groups payload', () => {
       expect(getGroupsList({ groups: newState })).toMatchObject(LIST_GROUPS_OK);
+    });
+  });
+
+  describe('after action SET_MY_GROUPS', () => {
+    let newState;
+    beforeEach(() => {
+      newState = reducer(state, setMyGroups(LIST_GROUPS_OK));
+    });
+
+    it('should define the groups payload', () => {
+      expect(getMyGroupsList({ groups: newState })).toEqual(LIST_GROUPS_OK.map(g => g.code));
     });
   });
 

--- a/test/state/groups/selectors.test.js
+++ b/test/state/groups/selectors.test.js
@@ -11,6 +11,7 @@ import {
   getGroupsMap,
   getGroupsList,
   getGroupEntries,
+  getMyGroupsList,
 } from 'state/groups/selectors';
 
 describe('state/groups/selectors', () => {
@@ -38,6 +39,10 @@ describe('state/groups/selectors', () => {
 
   it('verify getGroupsList selector', () => {
     expect(getGroupsList(GROUPS_NORMALIZED)).toEqual(LIST_GROUPS_OK);
+  });
+
+  it('verify getMyGroupsList selector', () => {
+    expect(getMyGroupsList(GROUPS_NORMALIZED)).toEqual(GROUPS_NORMALIZED.groups.myGroupsList);
   });
 
   it('verify getGroupEntries selector', () => {

--- a/test/test/mocks/groups.js
+++ b/test/test/mocks/groups.js
@@ -48,6 +48,7 @@ export const BODY_OK = {
 
 export const GROUPS_NORMALIZED = {
   groups: {
+    myGroupsList: ['administrators'],
     list: [
       'account_executive',
       'administrators',
@@ -192,13 +193,13 @@ export const CONTENT_REFERENCES = [
 ];
 
 export const RESOURCE_REFERENCES =
-[
-  {
-    code: 'sample-image-1',
-    name: 'Sample image 1',
-    type: 'Image',
-  },
-];
+  [
+    {
+      code: 'sample-image-1',
+      name: 'Sample image 1',
+      type: 'Image',
+    },
+  ];
 
 export const MOCK_REFERENCES = {
   jacmsContentManager: CONTENT_REFERENCES,

--- a/test/ui/pages/common/PageTree.test.js
+++ b/test/ui/pages/common/PageTree.test.js
@@ -15,6 +15,7 @@ const PAGES = [
     depth: 0,
     isEmpty: false,
     expanded: true,
+    ownerGroup: 'administrators',
   },
   {
     code: 'services',
@@ -24,6 +25,7 @@ const PAGES = [
     depth: 0,
     isEmpty: true,
     expanded: true,
+    ownerGroup: 'free',
   },
 ];
 
@@ -42,6 +44,7 @@ const props = {
   loading: false,
   pages: PAGES,
   locale: 'en',
+  myGroupIds: ['administrators', 'free'],
 };
 
 jest.unmock('react-redux');

--- a/test/ui/pages/common/PageTreeActionMenu.test.js
+++ b/test/ui/pages/common/PageTreeActionMenu.test.js
@@ -23,14 +23,19 @@ const locale = 'en';
 const PUBLISHED_PAGE = {
   code: 'publishedpage',
   status: 'published',
+  ownerGroup: 'free',
+  isEmpty: true,
 };
 const UNPUBLISHED_PAGE = {
   code: 'unpublishedpage',
   status: 'unpublished',
+  ownerGroup: 'administrators',
 };
 const DRAFT_PAGE = {
   code: 'draftpage',
   status: 'draft',
+  isEmpty: true,
+  ownerGroup: 'administrators',
 };
 
 describe('PageTreeActionMenu', () => {
@@ -42,6 +47,7 @@ describe('PageTreeActionMenu', () => {
         page={DRAFT_PAGE}
         domain={domain}
         locale={locale}
+        myGroupIds={['administrators', 'free']}
       />));
     expect(component.exists()).toEqual(true);
   });
@@ -52,6 +58,7 @@ describe('PageTreeActionMenu', () => {
         page={DRAFT_PAGE}
         domain={domain}
         locale={locale}
+        myGroupIds={['administrators', 'free']}
       />));
     component.find('.PageTreeActionMenuButton__menu-item-add').simulate('click', EVENT);
     expect(onClickAdd).not.toHaveBeenCalled();
@@ -65,6 +72,7 @@ describe('PageTreeActionMenu', () => {
           page={DRAFT_PAGE}
           domain={domain}
           locale={locale}
+          myGroupIds={['administrators', 'free']}
         />));
     });
     it('renders the Publish menu item', () => {
@@ -91,6 +99,7 @@ describe('PageTreeActionMenu', () => {
           page={UNPUBLISHED_PAGE}
           domain={domain}
           locale={locale}
+          myGroupIds={['administrators', 'free']}
         />));
     });
     it('renders the Publish menu item', () => {
@@ -118,6 +127,7 @@ describe('PageTreeActionMenu', () => {
           page={PUBLISHED_PAGE}
           domain={domain}
           locale={locale}
+          myGroupIds={['administrators', 'free']}
         />));
     });
     it('renders the Unpublish menu item', () => {
@@ -153,6 +163,7 @@ describe('PageTreeActionMenu', () => {
           onClickPreview={onClickPreview}
           domain={domain}
           locale={locale}
+          myGroupIds={['administrators', 'free']}
         />
       ));
     });
@@ -177,8 +188,7 @@ describe('PageTreeActionMenu', () => {
       expect(onClickClone).toHaveBeenCalled();
     });
     it('Delete calls onClickDelete', () => {
-      component.find('.PageTreeActionMenuButton__menu-item-delete').prop('onSelect')();
-      expect(onClickDelete).toHaveBeenCalled();
+      expect(component.find('.PageTreeActionMenuButton__menu-item-delete').prop('disabled')).toBe(true);
     });
     it('Publish calls onClickPublish', () => {
       component.find('.PageTreeActionMenuButton__menu-item-publish').prop('onSelect')();
@@ -195,6 +205,7 @@ describe('PageTreeActionMenu', () => {
           onClickUnpublish={onClickUnpublish}
           domain={domain}
           locale={locale}
+          myGroupIds={['administrators', 'free']}
         />
       ));
       component.find('.PageTreeActionMenuButton__menu-item-unpublish').prop('onSelect')();
@@ -207,6 +218,7 @@ describe('PageTreeActionMenu', () => {
           onClickViewPublishedPage={onClickViewPublishedPage}
           domain={domain}
           locale={locale}
+          myGroupIds={['administrators', 'free']}
         />
       ));
       component.find('.PageTreeActionMenuButton__menu-item-viewPublishedPage').prop('onClick')();

--- a/test/ui/pages/common/PageTreeContainer.test.js
+++ b/test/ui/pages/common/PageTreeContainer.test.js
@@ -18,6 +18,7 @@ import { MODAL_ID as UNPUBLISH_MODAL_ID } from 'ui/pages/common/UnpublishPageMod
 import { PAGE_MOVEMENT_OPTIONS } from 'state/pages/const';
 import { MODAL_ID as MOVE_MODAL_ID } from 'ui/pages/common/MovePageModal';
 import { history } from 'app-init/router';
+import { getGroupsIdList } from 'state/groups/selectors';
 
 history.push = jest.fn();
 
@@ -51,6 +52,11 @@ jest.mock('state/pages/selectors', () => ({
   getSearchPages: jest.fn(),
 }));
 
+jest.mock('state/groups/selectors', () => ({
+  getGroupsIdList: jest.fn(),
+}));
+
+getGroupsIdList.mockReturnValue(['administrators', 'free']);
 getPageTreePages.mockReturnValue('pages');
 getSearchPages.mockReturnValue([]);
 

--- a/test/ui/pages/common/PageTreeContainer.test.js
+++ b/test/ui/pages/common/PageTreeContainer.test.js
@@ -18,7 +18,7 @@ import { MODAL_ID as UNPUBLISH_MODAL_ID } from 'ui/pages/common/UnpublishPageMod
 import { PAGE_MOVEMENT_OPTIONS } from 'state/pages/const';
 import { MODAL_ID as MOVE_MODAL_ID } from 'ui/pages/common/MovePageModal';
 import { history } from 'app-init/router';
-import { getGroupsIdList } from 'state/groups/selectors';
+import { getMyGroupsList } from 'state/groups/selectors';
 
 history.push = jest.fn();
 
@@ -53,10 +53,10 @@ jest.mock('state/pages/selectors', () => ({
 }));
 
 jest.mock('state/groups/selectors', () => ({
-  getGroupsIdList: jest.fn(),
+  getMyGroupsList: jest.fn(),
 }));
 
-getGroupsIdList.mockReturnValue(['administrators', 'free']);
+getMyGroupsList.mockReturnValue(['administrators', 'free']);
 getPageTreePages.mockReturnValue('pages');
 getSearchPages.mockReturnValue([]);
 

--- a/test/ui/pages/config/ContentPageContainer.test.js
+++ b/test/ui/pages/config/ContentPageContainer.test.js
@@ -2,7 +2,7 @@ import { mapStateToProps, mapDispatchToProps } from 'ui/pages/config/ContentPage
 import { HOMEPAGE_PAYLOAD, SEARCH_PAGES } from 'test/mocks/pages';
 import { getPageTreePages, getSearchPages, getSelectedPage } from 'state/pages/selectors';
 import { getUserPreferences } from 'state/user-preferences/selectors';
-import { getGroupsIdList } from 'state/groups/selectors';
+import { getMyGroupsList } from 'state/groups/selectors';
 
 jest.mock('state/pages/selectors', () => ({
   getPageTreePages: jest.fn(),
@@ -21,14 +21,14 @@ jest.mock('state/user-preferences/selectors', () => ({
 }));
 
 jest.mock('state/groups/selectors', () => ({
-  getGroupsIdList: jest.fn(),
+  getMyGroupsList: jest.fn(),
 }));
 
 getPageTreePages.mockReturnValue([HOMEPAGE_PAYLOAD]);
 getSearchPages.mockReturnValue([SEARCH_PAGES]);
 getSelectedPage.mockReturnValue(HOMEPAGE_PAYLOAD);
 getUserPreferences.mockReturnValue({});
-getGroupsIdList.mockReturnValue(['administrators', 'free']);
+getMyGroupsList.mockReturnValue(['administrators', 'free']);
 
 describe('ContentPagesContainer', () => {
   describe('mapStateToProps', () => {

--- a/test/ui/pages/config/ContentPageContainer.test.js
+++ b/test/ui/pages/config/ContentPageContainer.test.js
@@ -2,6 +2,7 @@ import { mapStateToProps, mapDispatchToProps } from 'ui/pages/config/ContentPage
 import { HOMEPAGE_PAYLOAD, SEARCH_PAGES } from 'test/mocks/pages';
 import { getPageTreePages, getSearchPages, getSelectedPage } from 'state/pages/selectors';
 import { getUserPreferences } from 'state/user-preferences/selectors';
+import { getGroupsIdList } from 'state/groups/selectors';
 
 jest.mock('state/pages/selectors', () => ({
   getPageTreePages: jest.fn(),
@@ -19,10 +20,15 @@ jest.mock('state/user-preferences/selectors', () => ({
   getUserPreferences: jest.fn(),
 }));
 
+jest.mock('state/groups/selectors', () => ({
+  getGroupsIdList: jest.fn(),
+}));
+
 getPageTreePages.mockReturnValue([HOMEPAGE_PAYLOAD]);
 getSearchPages.mockReturnValue([SEARCH_PAGES]);
 getSelectedPage.mockReturnValue(HOMEPAGE_PAYLOAD);
 getUserPreferences.mockReturnValue({});
+getGroupsIdList.mockReturnValue(['administrators', 'free']);
 
 describe('ContentPagesContainer', () => {
   describe('mapStateToProps', () => {

--- a/test/ui/pages/edit/PagesEditFormContainer.test.js
+++ b/test/ui/pages/edit/PagesEditFormContainer.test.js
@@ -1,5 +1,5 @@
 import { mapDispatchToProps, mapStateToProps } from 'ui/pages/edit/PagesEditFormContainer';
-import { getGroupsList, getGroupEntries } from 'state/groups/selectors';
+import { getGroupsList, getGroupEntries, getMyGroupsList } from 'state/groups/selectors';
 import { getActiveLanguages } from 'state/languages/selectors';
 import { LANGUAGES_LIST as LANGUAGES } from 'test/mocks/languages';
 
@@ -33,6 +33,7 @@ const GROUPS = [{ code: 'group', name: 'groupName' }];
 jest.mock('state/groups/selectors', () => ({
   getGroupsList: jest.fn(),
   getGroupEntries: jest.fn(),
+  getMyGroupsList: jest.fn(),
 }));
 
 getGroupsList.mockReturnValue(GROUPS);
@@ -53,6 +54,7 @@ jest.mock('state/languages/selectors', () => ({
 }));
 
 getActiveLanguages.mockReturnValue(LANGUAGES);
+getMyGroupsList.mockReturnValue(['administrators', 'free']);
 
 const PAGE_CODE = 'page_code';
 const STATE = {};


### PR DESCRIPTION
@gReis89 @raxkaynan @jeffgo10 please note that I have changed line 156 in `src/state/groups/actions.js` file. Since, `setGroups` is used for setting `myGroups`, where `groupEntries` are all available groups. The reason why it was working correctly is that we were pushing the user to group list (after creating a new group), so we are re-fetching all group entries again and it sets them correctly, so in fact it did not really matter what we left on line 156, even if we removed it it would have worked. Please give me your thought if you think otherwise