### PR TITLE
ENG-3381: preventing filebrowser route to refresh path after canceling an action

### DIFF
--- a/src/state/file-browser/actions.js
+++ b/src/state/file-browser/actions.js
@@ -71,7 +71,7 @@ export const fetchFile = (filename, extensions = ['.txt']) => (dispatch, getStat
     }
   });
 
-export const fetchFileList = (protectedFolder = '', path = '') => dispatch =>
+export const fetchFileList = (protectedFolder = '', path = '', shouldKeepPath) => dispatch =>
   new Promise((resolve) => {
     dispatch(toggleLoading('files'));
     const queryString = [];
@@ -87,7 +87,9 @@ export const fetchFileList = (protectedFolder = '', path = '') => dispatch =>
         if (response.ok) {
           history.push(ROUTE_FILE_BROWSER);
           dispatch(setFileList(json.payload));
-          dispatch(setPathInfo(json.metaData));
+          if (!shouldKeepPath) {
+            dispatch(setPathInfo(json.metaData));
+          }
         } else {
           dispatch(addErrors(json.errors.map(e => e.message)));
           json.errors.forEach(err => dispatch(addToast(err.message, TOAST_ERROR)));

--- a/src/ui/file-browser/add/CreateFolderForm.js
+++ b/src/ui/file-browser/add/CreateFolderForm.js
@@ -62,7 +62,7 @@ export class CreateFolderFormBody extends Component {
             <Button
               className="pull-right FileBrowserCreateFolderForm__btn-cancel"
               componentClass={Link}
-              to={ROUTE_FILE_BROWSER}
+              to={{ pathname: ROUTE_FILE_BROWSER, state: { keepPath: true } }}
             >
               <FormattedMessage id="app.cancel" />
             </Button>

--- a/src/ui/file-browser/common/CreateTextFileForm.js
+++ b/src/ui/file-browser/common/CreateTextFileForm.js
@@ -127,7 +127,7 @@ export class CreateTextFileFormBody extends Component {
             <Button
               className="pull-right CreateTextFileForm__btn-cancel"
               componentClass={Link}
-              to={ROUTE_FILE_BROWSER}
+              to={{ pathname: ROUTE_FILE_BROWSER, state: { keepPath: true } }}
             >
               <FormattedMessage id="app.cancel" />
             </Button>

--- a/src/ui/file-browser/list/FilesListTableContainer.js
+++ b/src/ui/file-browser/list/FilesListTableContainer.js
@@ -18,9 +18,14 @@ export const mapStateToProps = state => (
   }
 );
 
-export const mapDispatchToProps = dispatch => ({
+export const mapDispatchToProps = (dispatch, ownProps) => ({
   onWillMount: (protectedFolder = '', path = '') => {
-    dispatch(fetchFileList(protectedFolder, path));
+    let shouldKeepPath = false;
+    if (ownProps.location.state) {
+      const { keepPath } = ownProps.location.state;
+      shouldKeepPath = keepPath;
+    }
+    dispatch(fetchFileList(protectedFolder, path, shouldKeepPath));
   },
   onClickDownload: (file) => {
     dispatch(downloadFile(file)).then((base64) => { download(file.name, base64); });

--- a/src/ui/file-browser/list/ListFilesPage.js
+++ b/src/ui/file-browser/list/ListFilesPage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Grid, Row, Col, Breadcrumb } from 'patternfly-react';
 import { FormattedMessage } from 'react-intl';
+import PropTypes from 'prop-types';
 
 import BreadcrumbItem from 'ui/common/BreadcrumbItem';
 
@@ -12,7 +13,7 @@ import FileButtonsGroupContainer from 'ui/file-browser/common/FileButtonsGroupCo
 import withPermissions from 'ui/auth/withPermissions';
 import { SUPERUSER_PERMISSION } from 'state/permissions/const';
 
-export const ListFilesPageBody = () => (
+export const ListFilesPageBody = ({ location }) => (
   <InternalPage className="ListFilesPage">
     <Grid fluid>
       <Row>
@@ -47,10 +48,14 @@ export const ListFilesPageBody = () => (
         <br />
       </Row>
       <Row>
-        <FilesListTableContainer className="ListFilesPage__fileListTableContainer" />
+        <FilesListTableContainer className="ListFilesPage__fileListTableContainer" location={location} />
       </Row>
     </Grid>
   </InternalPage>
 );
+
+ListFilesPageBody.propTypes = {
+  location: PropTypes.shape({}).isRequired,
+};
 
 export default withPermissions(SUPERUSER_PERMISSION)(ListFilesPageBody);

--- a/src/ui/file-browser/upload/UploadFileBrowserForm.js
+++ b/src/ui/file-browser/upload/UploadFileBrowserForm.js
@@ -35,7 +35,7 @@ export const UploadFileBrowserBody = (props) => {
               <Icon size="lg" name="upload" />&nbsp;
               <FormattedMessage id="app.upload" />
             </Button>
-            <Link to={ROUTE_FILE_BROWSER}>
+            <Link to={{ pathname: ROUTE_FILE_BROWSER, state: { keepPath: true } }}>
               <Button
                 className="pull-right UploadFileBrowserForm__btn-cancel"
               >

--- a/test/ui/file-browser/list/FilesListTableContainer.test.js
+++ b/test/ui/file-browser/list/FilesListTableContainer.test.js
@@ -39,6 +39,10 @@ getPathInfo.mockReturnValue(path);
 
 const dispatchMock = jest.fn(() => Promise.resolve({}));
 
+const ownProps = {
+  location: {},
+};
+
 describe('FilesListTableContainer', () => {
   describe('mapStateToProps', () => {
     it('maps files List property state', () => {
@@ -50,7 +54,7 @@ describe('FilesListTableContainer', () => {
   describe('mapDispatchToProps', () => {
     let props;
     beforeEach(() => {
-      props = mapDispatchToProps(dispatchMock);
+      props = mapDispatchToProps(dispatchMock, ownProps);
     });
 
     it('should map the correct function properties', () => {


### PR DESCRIPTION
using react-router `state` to prevent `/file-browser` route to reset path info if users click on cancel buttons