### PR TITLE
ENG-3376 Fix file browser breadcrumbs not working properly

### DIFF
--- a/src/state/file-browser/actions.js
+++ b/src/state/file-browser/actions.js
@@ -85,7 +85,7 @@ export const fetchFileList = (protectedFolder = '', path = '') => dispatch =>
     getFileBrowser(`?${queryString.join('&')}`).then((response) => {
       response.json().then((json) => {
         if (response.ok) {
-          history.push(ROUTE_FILE_BROWSER);
+          history.push(ROUTE_FILE_BROWSER, { from: history.location.pathname });
           dispatch(setFileList(json.payload));
           dispatch(setPathInfo(json.metaData));
         } else {

--- a/src/ui/file-browser/add/CreateFolderForm.js
+++ b/src/ui/file-browser/add/CreateFolderForm.js
@@ -26,7 +26,7 @@ export class CreateFolderFormBody extends Component {
 
   render() {
     const {
-      intl, invalid, submitting,
+      intl, invalid, submitting, history,
     } = this.props;
 
     return (
@@ -62,7 +62,7 @@ export class CreateFolderFormBody extends Component {
             <Button
               className="pull-right FileBrowserCreateFolderForm__btn-cancel"
               componentClass={Link}
-              to={ROUTE_FILE_BROWSER}
+              to={{ pathname: ROUTE_FILE_BROWSER, state: { from: history.location.pathname } }}
             >
               <FormattedMessage id="app.cancel" />
             </Button>
@@ -78,6 +78,11 @@ CreateFolderFormBody.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
   invalid: PropTypes.bool.isRequired,
   submitting: PropTypes.bool.isRequired,
+  history: PropTypes.shape({
+    location: PropTypes.shape({
+      pathname: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
 };
 
 const CreateFolderForm = reduxForm({

--- a/src/ui/file-browser/add/CreateFolderFormContainer.js
+++ b/src/ui/file-browser/add/CreateFolderFormContainer.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 import { sendPostCreateFolder } from 'state/file-browser/actions';
 import CreateFolderForm from 'ui/file-browser/add/CreateFolderForm';
 
@@ -8,6 +9,10 @@ export const mapDispatchToProps = dispatch => ({
   },
 });
 
-export default connect(null, mapDispatchToProps, null, {
-  pure: false,
-})(CreateFolderForm);
+export default withRouter(connect(
+  null,
+  mapDispatchToProps,
+  null, {
+    pure: false,
+  },
+)(CreateFolderForm));

--- a/src/ui/file-browser/add/CreateTextFileFormContainer.js
+++ b/src/ui/file-browser/add/CreateTextFileFormContainer.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 import CreateTextFileForm from 'ui/file-browser/common/CreateTextFileForm';
 import { saveFile } from 'state/file-browser/actions';
 
@@ -16,6 +17,10 @@ export const mapDispatchToProps = dispatch => ({
   },
 });
 
-export default connect(mapStateToProps, mapDispatchToProps, null, {
-  pure: false,
-})(CreateTextFileForm);
+export default withRouter(connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  null, {
+    pure: false,
+  },
+)(CreateTextFileForm));

--- a/src/ui/file-browser/common/CreateTextFileForm.js
+++ b/src/ui/file-browser/common/CreateTextFileForm.js
@@ -49,7 +49,7 @@ export class CreateTextFileFormBody extends Component {
   }
   render() {
     const {
-      intl, invalid, submitting, handleSubmit, mode, filename, onClickDownload,
+      intl, invalid, submitting, handleSubmit, mode, filename, onClickDownload, history,
     } = this.props;
 
     return (
@@ -127,7 +127,7 @@ export class CreateTextFileFormBody extends Component {
             <Button
               className="pull-right CreateTextFileForm__btn-cancel"
               componentClass={Link}
-              to={ROUTE_FILE_BROWSER}
+              to={{ pathname: ROUTE_FILE_BROWSER, state: { from: history.location.pathname } }}
             >
               <FormattedMessage id="app.cancel" />
             </Button>
@@ -146,6 +146,11 @@ CreateTextFileFormBody.propTypes = {
   submitting: PropTypes.bool.isRequired,
   mode: PropTypes.string,
   filename: PropTypes.string,
+  history: PropTypes.shape({
+    location: PropTypes.shape({
+      pathname: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
 };
 
 CreateTextFileFormBody.defaultProps = {

--- a/src/ui/file-browser/list/FilesListTable.js
+++ b/src/ui/file-browser/list/FilesListTable.js
@@ -39,7 +39,7 @@ class FilesListTable extends Component {
     const getLinkItem = (file) => {
       if (file.directory) {
         return (
-          <a className="FilesListTable__link-dir" role="presentation" onClick={() => this.props.onWillMount(getProtectedFolder(file.path), getQueryString(file.path))}>
+          <a className="FilesListTable__link-dir" role="presentation" onClick={() => this.props.onPathChange(getProtectedFolder(file.path), getQueryString(file.path))}>
             <Icon size="lg" name="folder" /> {file.name}
           </a>
         );
@@ -91,12 +91,12 @@ class FilesListTable extends Component {
         return <div />;
       } else if (prev === null && current === '') {
         return (
-          <a className="FilesListTable__up-link" role="presentation" onClick={() => this.props.onWillMount()}>
+          <a className="FilesListTable__up-link" role="presentation" onClick={() => this.props.onPathChange()}>
             <Icon size="lg" name="share" className="fa-rotate-270" /> <FormattedMessage id="fileBrowser.list.upLink" />
           </a>);
       }
       return (
-        <a className="FilesListTable__up-link" role="presentation" onClick={() => this.props.onWillMount(pfolder, prev)}>
+        <a className="FilesListTable__up-link" role="presentation" onClick={() => this.props.onPathChange(pfolder, prev)}>
           <Icon size="lg" name="share" className="fa-rotate-270" /> <FormattedMessage id="fileBrowser.list.upLink" />
         </a>);
     };
@@ -173,6 +173,7 @@ FilesListTable.propTypes = {
   onClickDownload: PropTypes.func,
   onClickDeleteFolder: PropTypes.func,
   onClickDeleteFile: PropTypes.func,
+  onPathChange: PropTypes.func.isRequired,
   loading: PropTypes.bool,
   files: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.string,

--- a/src/ui/file-browser/list/FilesListTableContainer.js
+++ b/src/ui/file-browser/list/FilesListTableContainer.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
+import { withRouter } from 'react-router-dom';
 
 import { fetchFileList, downloadFile } from 'state/file-browser/actions';
 import { getFileList, getPathInfo } from 'state/file-browser/selectors';
@@ -9,6 +10,7 @@ import { download } from 'ui/file-browser/utils/downloadFile';
 import { setVisibleModal, setInfo } from 'state/modal/actions';
 import { DELETE_FOLDER_MODAL_ID } from 'ui/file-browser/common/DeleteFolderModal';
 import { DELETE_FILE_MODAL_ID } from 'ui/file-browser/common/DeleteFileModal';
+import { ROUTE_FILE_BROWSER } from 'app-init/router';
 
 export const mapStateToProps = state => (
   {
@@ -18,21 +20,27 @@ export const mapStateToProps = state => (
   }
 );
 
-export const mapDispatchToProps = dispatch => ({
-  onWillMount: (protectedFolder = '', path = '') => {
-    dispatch(fetchFileList(protectedFolder, path));
-  },
-  onClickDownload: (file) => {
-    dispatch(downloadFile(file)).then((base64) => { download(file.name, base64); });
-  },
-  onClickDeleteFolder: (file) => {
-    dispatch(setVisibleModal(DELETE_FOLDER_MODAL_ID));
-    dispatch(setInfo({ type: 'folder', file }));
-  },
-  onClickDeleteFile: (file) => {
-    dispatch(setVisibleModal(DELETE_FILE_MODAL_ID));
-    dispatch(setInfo({ type: 'file', file }));
-  },
-});
+export const mapDispatchToProps = (dispatch, { history }) => {
+  const prevLoc = history.location.state && history.location.state.from;
 
-export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(FilesListTable));
+  return ({
+    onWillMount: (protectedFolder = '', path = '') => {
+      if (!prevLoc || prevLoc === ROUTE_FILE_BROWSER || !prevLoc.startsWith(ROUTE_FILE_BROWSER)) {
+        dispatch(fetchFileList(protectedFolder, path));
+      }
+    },
+    onClickDownload: (file) => {
+      dispatch(downloadFile(file)).then((base64) => { download(file.name, base64); });
+    },
+    onClickDeleteFolder: (file) => {
+      dispatch(setVisibleModal(DELETE_FOLDER_MODAL_ID));
+      dispatch(setInfo({ type: 'folder', file }));
+    },
+    onClickDeleteFile: (file) => {
+      dispatch(setVisibleModal(DELETE_FILE_MODAL_ID));
+      dispatch(setInfo({ type: 'file', file }));
+    },
+  });
+};
+
+export default withRouter(injectIntl(connect(mapStateToProps, mapDispatchToProps)(FilesListTable)));

--- a/src/ui/file-browser/list/FilesListTableContainer.js
+++ b/src/ui/file-browser/list/FilesListTableContainer.js
@@ -29,6 +29,9 @@ export const mapDispatchToProps = (dispatch, { history }) => {
         dispatch(fetchFileList(protectedFolder, path));
       }
     },
+    onPathChange: (protectedFolder = '', path = '') => {
+      dispatch(fetchFileList(protectedFolder, path));
+    },
     onClickDownload: (file) => {
       dispatch(downloadFile(file)).then((base64) => { download(file.name, base64); });
     },

--- a/src/ui/file-browser/upload/UploadFileBrowserForm.js
+++ b/src/ui/file-browser/upload/UploadFileBrowserForm.js
@@ -10,7 +10,7 @@ import RenderFileInput from 'ui/common/form/RenderFileInput';
 
 export const UploadFileBrowserBody = (props) => {
   const {
-    handleSubmit, invalid, submitting, loading,
+    handleSubmit, invalid, submitting, loading, history,
   } = props;
 
   return (
@@ -35,7 +35,7 @@ export const UploadFileBrowserBody = (props) => {
               <Icon size="lg" name="upload" />&nbsp;
               <FormattedMessage id="app.upload" />
             </Button>
-            <Link to={ROUTE_FILE_BROWSER}>
+            <Link to={{ pathname: ROUTE_FILE_BROWSER, state: { from: history.location.pathname } }}>
               <Button
                 className="pull-right UploadFileBrowserForm__btn-cancel"
               >
@@ -55,6 +55,11 @@ UploadFileBrowserBody.propTypes = {
   invalid: PropTypes.bool,
   submitting: PropTypes.bool,
   loading: PropTypes.bool,
+  history: PropTypes.shape({
+    location: PropTypes.shape({
+      pathname: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
 };
 
 UploadFileBrowserBody.defaultProps = {

--- a/src/ui/file-browser/upload/UploadFileBrowserFormContainer.js
+++ b/src/ui/file-browser/upload/UploadFileBrowserFormContainer.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 import { getLoading } from 'state/loading/selectors';
 import UploadFileBrowserForm from 'ui/file-browser/upload/UploadFileBrowserForm';
 import { saveFile } from 'state/file-browser/actions';
@@ -11,6 +12,10 @@ export const mapDispatchToProps = dispatch => ({
   onSubmit: (values) => { values.file.files.map(f => dispatch(saveFile(f))); },
 });
 
-export default connect(mapStateToProps, mapDispatchToProps, null, {
-  pure: false,
-})(UploadFileBrowserForm);
+export default withRouter(connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  null, {
+    pure: false,
+  },
+)(UploadFileBrowserForm));

--- a/test/state/file-browser/actions.test.js
+++ b/test/state/file-browser/actions.test.js
@@ -27,6 +27,7 @@ jest.mock('state/file-browser/selectors', () => ({
 jest.mock('app-init/router', () => ({
   history: {
     push: jest.fn(),
+    location: {},
   },
 }));
 

--- a/test/ui/file-browser/add/CreateFolderForm.test.js
+++ b/test/ui/file-browser/add/CreateFolderForm.test.js
@@ -26,6 +26,7 @@ describe('CreateFolderForm', () => {
       handleSubmit,
       onWillMount,
       intl: mockIntl,
+      history: { location: {} },
     };
 
     return shallowWithIntl(<CreateFolderFormBody {...props} />);

--- a/test/ui/file-browser/common/CreateTextFileForm.test.js
+++ b/test/ui/file-browser/common/CreateTextFileForm.test.js
@@ -26,6 +26,7 @@ describe('CreateTextFileForm', () => {
       invalid,
       handleSubmit,
       intl: mockIntl,
+      history: { location: {} },
     };
 
     return shallowWithIntl(<CreateTextFileFormBody {...props} />);

--- a/test/ui/file-browser/list/FilesListTable.test.js
+++ b/test/ui/file-browser/list/FilesListTable.test.js
@@ -12,6 +12,7 @@ jest.mock('state/file-browser/selectors', () => ({
 const props = {
   onWillMount: jest.fn(),
   onClickDownload: jest.fn(),
+  onPathChange: jest.fn(),
   pathInfo: {
     protectedFolder: true,
     prevPath: '/first',
@@ -22,6 +23,7 @@ const props = {
 const propsRootFolder = {
   onWillMount: jest.fn(),
   onClickDownload: jest.fn(),
+  onPathChange: jest.fn(),
   pathInfo: {
     protectedFolder: null,
     prevPath: '',
@@ -32,6 +34,7 @@ const propsRootFolder = {
 const propsFirstLevelFolder = {
   onWillMount: jest.fn(),
   onClickDownload: jest.fn(),
+  onPathChange: jest.fn(),
   pathInfo: {
     protectedFolder: true,
     prevPath: '',

--- a/test/ui/file-browser/list/FilesListTableContainer.test.js
+++ b/test/ui/file-browser/list/FilesListTableContainer.test.js
@@ -58,10 +58,17 @@ describe('FilesListTableContainer', () => {
       expect(props.onClickDownload).toBeDefined();
       expect(props.onClickDeleteFolder).toBeDefined();
       expect(props.onClickDeleteFile).toBeDefined();
+      expect(props.onPathChange).toBeDefined();
     });
 
     it('should dispatch an action if onWillMount is called', () => {
       props.onWillMount({});
+      expect(dispatchMock).toHaveBeenCalled();
+      expect(fetchFileList).toHaveBeenCalled();
+    });
+
+    it('should dispatch an action if onPathChange is called', () => {
+      props.onPathChange({});
       expect(dispatchMock).toHaveBeenCalled();
       expect(fetchFileList).toHaveBeenCalled();
     });

--- a/test/ui/file-browser/list/FilesListTableContainer.test.js
+++ b/test/ui/file-browser/list/FilesListTableContainer.test.js
@@ -50,7 +50,7 @@ describe('FilesListTableContainer', () => {
   describe('mapDispatchToProps', () => {
     let props;
     beforeEach(() => {
-      props = mapDispatchToProps(dispatchMock);
+      props = mapDispatchToProps(dispatchMock, { history: { location: {} } });
     });
 
     it('should map the correct function properties', () => {

--- a/test/ui/file-browser/upload/UploadFileBrowserForm.test.js
+++ b/test/ui/file-browser/upload/UploadFileBrowserForm.test.js
@@ -9,7 +9,7 @@ const props = {
   submitting: false,
   invalid: false,
   handleSubmit,
-
+  history: { location: {} },
 };
 
 describe('UploadFileBrowserBody', () => {


### PR DESCRIPTION
Prevent action dispatch on mount of file browser page when navigating from a sub-route (i.e. via breadcrumb) since it redirects it to the root folder.