### PR TITLE
ENG-3311: change password API

### DIFF
--- a/__mocks__/api/users.js
+++ b/__mocks__/api/users.js
@@ -10,4 +10,4 @@ export const getUserAuthorities = jest.fn(mockApi({ payload: [] }));
 export const postUserAuthorities = jest.fn(mockApi({ payload: [] }));
 export const putUserAuthorities = jest.fn(mockApi({ payload: [] }));
 export const deleteUserAuthorities = jest.fn(mockApi({ payload: [] }));
-export const postUserPassword = jest.fn(mockApi({ payload: [] }));
+export const postMyPassword = jest.fn(mockApi({ payload: [] }));

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -73,8 +73,8 @@ export const deleteUserAuthorities = username => makeRequest({
   useAuthentication: true,
 });
 
-export const postUserPassword = (username, data) => makeRequest({
-  uri: `/api/users/${username}/password`,
+export const postMyPassword = data => makeRequest({
+  uri: '/api/users/myPassword',
   method: METHODS.POST,
   body: data,
   mockResponse: {},

--- a/src/state/users/actions.js
+++ b/src/state/users/actions.js
@@ -12,7 +12,7 @@ import {
   postUserAuthorities,
   putUserAuthorities,
   deleteUserAuthorities,
-  postUserPassword,
+  postMyPassword,
   postWizardSetting,
 } from 'api/users';
 import { setPage } from 'state/pagination/actions';
@@ -267,9 +267,9 @@ export const sendDeleteUserAuthorities = username => async (dispatch) => {
   }
 };
 
-export const sendPostUserPassword = (username, data) => async (dispatch) => {
+export const sendPostMyPassword = data => async (dispatch) => {
   try {
-    const response = await postUserPassword(username, data);
+    const response = await postMyPassword(data);
     const json = await response.json();
     if (response.ok) {
       dispatch(addToast(

--- a/src/ui/users/my-profile/AccountFormContainer.js
+++ b/src/ui/users/my-profile/AccountFormContainer.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { getUsername } from '@entando/apimanager';
 import { submit } from 'redux-form';
 
-import { sendPostUserPassword } from 'state/users/actions';
+import { sendPostMyPassword } from 'state/users/actions';
 import AccountForm from 'ui/users/my-profile/AccountForm';
 import { setVisibleModal } from 'state/modal/actions';
 
@@ -11,14 +11,8 @@ export const mapStateToProps = state => ({
 });
 
 export const mapDispatchToProps = dispatch => ({
-  onSubmit: (username, data) => {
-    dispatch(sendPostUserPassword(
-      username,
-      {
-        ...data,
-        username,
-      },
-    ));
+  onSubmit: (data) => {
+    dispatch(sendPostMyPassword(data));
   },
   onEdit: () => {
     dispatch(setVisibleModal(AccountForm.FORM_ID));
@@ -36,7 +30,8 @@ export default connect(
     ...dispatchProps,
     ...ownProps,
     onSubmit: (data) => {
-      dispatchProps.onSubmit(stateProps.username, data);
+      const { oldPassword, newPassword } = data;
+      dispatchProps.onSubmit({ oldPassword, newPassword });
     },
   }),
   { pure: false },

--- a/test/api/users.test.js
+++ b/test/api/users.test.js
@@ -9,7 +9,7 @@ import {
   postUserAuthorities,
   putUserAuthorities,
   deleteUserAuthorities,
-  postUserPassword,
+  postMyPassword,
 } from 'api/users';
 import { USER, USERS, ERROR, AUTHORITIES } from 'test/mocks/users';
 
@@ -216,19 +216,19 @@ describe('deleteUserAuthorities', () => {
   });
 });
 
-describe('postUserPassword', () => {
+describe('postMyPassword', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('returns a promise', () => {
-    expect(postUserPassword(USER.username, {})).toBeInstanceOf(Promise);
+    expect(postMyPassword({})).toBeInstanceOf(Promise);
   });
 
   it('makes the correct request with user body', () => {
-    postUserPassword(USER.username, {});
+    postMyPassword({});
     expect(makeRequest).toHaveBeenCalledWith(expect.objectContaining({
-      uri: `/api/users/${USER.username}/password`,
+      uri: '/api/users/myPassword',
       method: METHODS.POST,
       body: {},
       mockResponse: {},

--- a/test/state/users/actions.test.js
+++ b/test/state/users/actions.test.js
@@ -8,7 +8,7 @@ import {
   setUsers, fetchUsers, fetchUserForm, sendPostUser, sendPutUser,
   setSelectedUserDetail, fetchCurrentPageUserDetail, setUsersTotal,
   fetchUsersTotal, sendDeleteUser, fetchUserAuthorities, sendPostUserAuthorities,
-  sendPutUserAuthorities, sendDeleteUserAuthorities, sendPostUserPassword,
+  sendPutUserAuthorities, sendDeleteUserAuthorities, sendPostMyPassword,
 } from 'state/users/actions';
 import { SET_USERS, SET_SELECTED_USER, SET_SELECTED_USER_AUTHORITIES, SET_USERS_TOTAL } from 'state/users/types';
 import { TOGGLE_LOADING } from 'state/loading/types';
@@ -18,7 +18,7 @@ import { USER, USERS, AUTHORITIES } from 'test/mocks/users';
 import {
   getUsers, getUser, putUser, postUser, deleteUser,
   getUserAuthorities, postUserAuthorities, putUserAuthorities,
-  deleteUserAuthorities, postUserPassword,
+  deleteUserAuthorities, postMyPassword,
 } from 'api/users';
 import { history, ROUTE_USER_LIST } from 'app-init/router';
 
@@ -349,10 +349,10 @@ describe('state/users/actions', () => {
       });
     });
 
-    describe('sendPostUserPassword', () => {
-      it('when sendPostUserPassword succeeds, should dispatch ADD_TOAST and clearFields', (done) => {
-        store.dispatch(sendPostUserPassword('username', {})).then(() => {
-          expect(postUserPassword).toHaveBeenCalledWith('username', {});
+    describe('sendPostMyPassword', () => {
+      it('when sendPostMyPassword succeeds, should dispatch ADD_TOAST and clearFields', (done) => {
+        store.dispatch(sendPostMyPassword({})).then(() => {
+          expect(postMyPassword).toHaveBeenCalledWith({});
           const actions = store.getActions();
           expect(actions).toHaveLength(4);
           expect(actions[0]).toHaveProperty('type', ADD_TOAST);
@@ -364,9 +364,9 @@ describe('state/users/actions', () => {
       });
 
       it('if the response is not ok, dispatch add errors', async () => {
-        postUserPassword.mockImplementationOnce(mockApi({ errors: true }));
-        return store.dispatch(sendPostUserPassword('username', {})).catch((e) => {
-          expect(postUserPassword).toHaveBeenCalled();
+        postMyPassword.mockImplementationOnce(mockApi({ errors: true }));
+        return store.dispatch(sendPostMyPassword({})).catch((e) => {
+          expect(postMyPassword).toHaveBeenCalled();
           const actions = store.getActions();
           expect(actions).toHaveLength(1);
           expect(actions[0]).toHaveProperty('type', ADD_ERRORS);


### PR DESCRIPTION
change `postUserPassword` to `postMyPassword`. Users should only be able to set their own passwords.