### PR TITLE
ENG-3727 fix redirect loop

### DIFF
--- a/src/app-init/MfeDownloadManager.js
+++ b/src/app-init/MfeDownloadManager.js
@@ -1,16 +1,21 @@
 import React, { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
+import { getUsername } from '@entando/apimanager';
 
 import { fetchMfeConfigList } from 'state/mfe/actions';
 
 export default function MfeDownloadManager(props) {
   const { children } = props;
   const dispatch = useDispatch();
+  const currentUserName = useSelector(getUsername);
 
   useEffect(() => {
-    dispatch(fetchMfeConfigList());
-  }, [dispatch]);
+    // wait until apiManager is not initialised and only after that fetch the mfe config list
+    if (currentUserName) {
+      dispatch(fetchMfeConfigList());
+    }
+  }, [dispatch, currentUserName]);
 
 
   return <div>{children}</div>;

--- a/src/index.js
+++ b/src/index.js
@@ -35,13 +35,13 @@ export default ReactDOM.render(
   <Provider store={store}>
     <AuthProvider store={store}>
       <IntlProviderContainer>
-        <MfeDownloadManager>
-          <ApiManager store={store}>
+        <ApiManager store={store}>
+          <MfeDownloadManager>
             <Router history={history}>
               <AppContainer />
             </Router>
-          </ApiManager>
-        </MfeDownloadManager>
+          </MfeDownloadManager>
+        </ApiManager>
       </IntlProviderContainer>
     </AuthProvider>
   </Provider>,


### PR DESCRIPTION
The problem was regarding with `MfeDownloader` making API call before `apiManager` had finished initialisation. So, API call was failing and error state would logout the user.

This PR makes sure `apiManager` is initialised (when we have the current user's name from `apiManager` it means it has finished initialisation).