### PR TITLE
ENG-3663 fix breaking edit PageTemplate page

### DIFF
--- a/src/state/page-templates/actions.js
+++ b/src/state/page-templates/actions.js
@@ -141,6 +141,7 @@ export const loadSelectedPageTemplate = pageTemplateCode => (dispatch, getState)
   return fetchPageTemplate(pageTemplateCode)(dispatch)
     .then((json) => {
       const pageObject = json.payload;
+      pageObject.configuration = JSON.stringify(pageObject.configuration, null, 2);
       dispatch(setSelectedPageTemplate(pageObject));
       return pageObject;
     }).catch(() => {});

--- a/src/ui/page-templates/common/PageTemplateForm.js
+++ b/src/ui/page-templates/common/PageTemplateForm.js
@@ -67,7 +67,7 @@ const PageTemplateFormBody = ({
   useEffect(() => {
     onDidMount();
     return () => onWillUnmount();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const isEditMode = mode === FORM_MODE_EDIT;
@@ -259,7 +259,7 @@ const PageTemplateForm = withFormik({
             return jsonTest;
           }
           const previewErrors = validateFrames(JSON.parse(value).frames);
-          if (previewErrors.length) {
+          if (previewErrors && previewErrors.length) {
             const errors = previewErrors.map(({ id, values }) => {
               const errMsgs = defineMessages({
                 err: { id },

--- a/src/ui/page-templates/detail/PageTemplateDetailTable.js
+++ b/src/ui/page-templates/detail/PageTemplateDetailTable.js
@@ -26,7 +26,7 @@ class PageTemplateDetailTable extends Component {
               <FormattedMessage id="app.name" />
             </th>
             <td>
-              { pageTemplate.descr }
+              {pageTemplate.descr}
             </td>
           </tr>
           <tr>
@@ -34,7 +34,7 @@ class PageTemplateDetailTable extends Component {
               <FormattedMessage id="app.code" />
             </th>
             <td>
-              { pageTemplate.code }
+              {pageTemplate.code}
             </td>
           </tr>
           <tr>
@@ -51,7 +51,7 @@ class PageTemplateDetailTable extends Component {
             </th>
             <td>
               <pre>
-                { JSON.stringify(pageTemplate.configuration, null, 2) }
+                {pageTemplate.configuration}
               </pre>
             </td>
           </tr>
@@ -61,7 +61,7 @@ class PageTemplateDetailTable extends Component {
             </th>
             <td>
               <pre className="PageTemplateDetailTable__template">
-                { pageTemplate.template }
+                {pageTemplate.template}
               </pre>
             </td>
           </tr>
@@ -82,7 +82,7 @@ class PageTemplateDetailTable extends Component {
     const { loading } = this.props;
     return (
       <Spinner loading={loading}>
-        { this.renderContent() }
+        {this.renderContent()}
       </Spinner>
     );
   }


### PR DESCRIPTION
- Break was happening because of `codemirror` library. If we provide object it does not work, we need to give stringified object always.