### PR TITLE
ENG-3663: fixing page designer

### DIFF
--- a/src/state/page-templates/actions.js
+++ b/src/state/page-templates/actions.js
@@ -141,7 +141,7 @@ export const loadSelectedPageTemplate = pageTemplateCode => (dispatch, getState)
   return fetchPageTemplate(pageTemplateCode)(dispatch)
     .then((json) => {
       const pageObject = json.payload;
-      pageObject.configuration = JSON.stringify(pageObject.configuration, null, 2);
+      // pageObject.configuration = JSON.stringify(pageObject.configuration, null, 2);
       dispatch(setSelectedPageTemplate(pageObject));
       return pageObject;
     }).catch(() => {});

--- a/src/state/page-templates/selectors.js
+++ b/src/state/page-templates/selectors.js
@@ -45,6 +45,20 @@ export const getSelectedPageTemplateDefaultConfig = createSelector(
   },
 );
 
+export const getSelectedPageTemplateStringified = createSelector(
+  [getSelectedPageTemplate],
+  (pageTemplate) => {
+    let configuration = get(pageTemplate, 'configuration', '');
+    if (configuration instanceof Object) {
+      configuration = JSON.stringify(configuration);
+    }
+    return {
+      ...pageTemplate,
+      configuration,
+    };
+  },
+);
+
 export const getFormPageTemplate = createSelector(
   [getPageTemplateForm],
   pageTemplateForm => convertPageTemplateForm(pageTemplateForm),

--- a/src/ui/page-templates/common/PageTemplateFormContainer.js
+++ b/src/ui/page-templates/common/PageTemplateFormContainer.js
@@ -3,7 +3,7 @@ import { clearErrors } from '@entando/messages';
 import { withRouter } from 'react-router-dom';
 import { routeConverter } from '@entando/utils';
 
-import { getSelectedPageTemplate } from 'state/page-templates/selectors';
+import { getSelectedPageTemplateStringified } from 'state/page-templates/selectors';
 import {
   initPageTemplateForm,
   updatePageTemplate,
@@ -19,7 +19,7 @@ import { ROUTE_PAGE_TEMPLATE_LIST } from 'app-init/router';
 import PageTemplateForm from 'ui/page-templates/common/PageTemplateForm';
 
 export const mapStateToProps = state => ({
-  initialValues: getSelectedPageTemplate(state) || DEFAULT_FORM_VALUES,
+  initialValues: getSelectedPageTemplateStringified(state) || DEFAULT_FORM_VALUES,
 });
 
 export const mapDispatchToProps = (dispatch, { mode, match: { params }, history }) => ({

--- a/src/ui/page-templates/detail/PageTemplateDetailTable.js
+++ b/src/ui/page-templates/detail/PageTemplateDetailTable.js
@@ -51,7 +51,7 @@ class PageTemplateDetailTable extends Component {
             </th>
             <td>
               <pre>
-                {pageTemplate.configuration}
+                { JSON.stringify(pageTemplate.configuration, null, 2) }
               </pre>
             </td>
           </tr>


### PR DESCRIPTION
After merging the [PR](https://github.com/entando/app-builder/pull/1325) with the fix for [ENG-3663](https://entando.myjetbrains.com/youtrack/issue/ENG-3663), the Page Designer started to crash, because it needs the PageTempalte configs to be an object in the redux store. I rolled back some of the changes and fixed the issue on a different way to keep the redux state untouched.