### PR TITLE
ENG-4203 clear input results fix

### DIFF
--- a/src/state/labels/actions.js
+++ b/src/state/labels/actions.js
@@ -50,7 +50,7 @@ export const fetchLabels = (page = { page: 1, pageSize: 10 }) => (dispatch, getS
     dispatch(toggleLoading('systemLabels'));
 
     const filters = getLabelFilters(getState());
-    const params = filters ? convertToQueryString({
+    const params = filters && filters.keyword ? convertToQueryString({
       formValues: { key: filters.keyword },
       operators: { key: FILTER_OPERATORS.LIKE },
     }) : '';


### PR DESCRIPTION
- if `keyword` was undefined, FE was still sending `keyword: undefined` in the search query and BE was sending back empty results. We should not send `keyword` as a search criteria if its not truthy value