### PR TITLE
ENG-4197 Fix widget form config UI not showing unless focused

### DIFF
--- a/src/ui/common/form/JsonCodeEditorRenderer.js
+++ b/src/ui/common/form/JsonCodeEditorRenderer.js
@@ -44,7 +44,7 @@ JsonCodeEditorRenderer.propTypes = {
   }),
   help: PropTypes.node,
   input: PropTypes.shape({
-    value: PropTypes.oneOf([PropTypes.string, PropTypes.number]),
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     onChange: PropTypes.func.isRequired,
     onBlur: PropTypes.func.isRequired,
     onFocus: PropTypes.func.isRequired,

--- a/src/ui/widgets/common/WidgetForm.js
+++ b/src/ui/widgets/common/WidgetForm.js
@@ -271,7 +271,7 @@ export class WidgetFormBody extends Component {
           <div className="WidgetForm__body">
             <div className="WidgetForm__container">
               <fieldset className="no-padding">
-                <Tabs className="WidgetForm__tabs" id="basic-tabs">
+                <Tabs className="WidgetForm__tabs" id="basic-tabs" mountOnEnter>
                   {!parentWidgetParameters.length &&
                     <Tab eventKey={1} title={`${intl.formatMessage(msgs.customUi)} *`} >
                       <Field

--- a/src/ui/widgets/edit/EditWidgetFormContainer.js
+++ b/src/ui/widgets/edit/EditWidgetFormContainer.js
@@ -29,7 +29,7 @@ export const mapStateToProps = (state) => {
     defaultUIField: getSelectedWidgetDefaultUi(state),
     languages: getActiveLanguages(state),
     loading: getLoading(state).fetchWidget,
-    configUiRequired: isMicrofrontendWidgetForm(widget),
+    configUiRequired: !!isMicrofrontendWidgetForm(widget),
     widget,
   });
 };


### PR DESCRIPTION
Codemirror (the code editor library used) doesn't insert the values when it isn't displayed (i.e. contained in inactive Tab) even when it is already rendered and only "refreshes" it when focused. The fix is making the Tabs mount on enter (via `mountOnEnter` prop), which prevents the initial rendering of the code editor until its parent Tab is active.