### PR TITLE
ENG-4486 Fix group details 'Pages' tab sometimes not showing list

### DIFF
--- a/src/ui/groups/detail/GroupDetailTabPages.js
+++ b/src/ui/groups/detail/GroupDetailTabPages.js
@@ -23,16 +23,16 @@ class GroupDetailTabPages extends React.Component {
     this.changePageSize = this.changePageSize.bind(this);
   }
 
-  componentWillMount() {
-    this.props.onWillMount(this.props.page);
+  componentDidMount() {
+    this.props.onDidMount(this.props.page);
   }
 
   changePage(page) {
-    this.props.onWillMount({ page, pageSize: this.props.pageSize });
+    this.props.onDidMount({ page, pageSize: this.props.pageSize });
   }
 
   changePageSize(pageSize) {
-    this.props.onWillMount({ page: 1, pageSize });
+    this.props.onDidMount({ page: 1, pageSize });
   }
 
   renderRows() {
@@ -110,6 +110,8 @@ class GroupDetailTabPages extends React.Component {
   }
 
   render() {
+    console.log(this.props.pageReferences);
+
     return (
       <div className="GroupDetailTabPages">
         <Spinner loading={this.props.loading} >
@@ -122,7 +124,7 @@ class GroupDetailTabPages extends React.Component {
 
 GroupDetailTabPages.propTypes = {
   intl: intlShape.isRequired,
-  onWillMount: PropTypes.func,
+  onDidMount: PropTypes.func,
   loading: PropTypes.bool,
   pageReferences: PropTypes.arrayOf(PropTypes.shape({
     code: PropTypes.string,
@@ -134,7 +136,7 @@ GroupDetailTabPages.propTypes = {
 };
 
 GroupDetailTabPages.defaultProps = {
-  onWillMount: () => {},
+  onDidMount: () => {},
   loading: false,
   pageReferences: [],
 };

--- a/src/ui/groups/detail/GroupDetailTabPages.js
+++ b/src/ui/groups/detail/GroupDetailTabPages.js
@@ -110,8 +110,6 @@ class GroupDetailTabPages extends React.Component {
   }
 
   render() {
-    console.log(this.props.pageReferences);
-
     return (
       <div className="GroupDetailTabPages">
         <Spinner loading={this.props.loading} >

--- a/src/ui/groups/detail/GroupDetailTabPagesContainer.js
+++ b/src/ui/groups/detail/GroupDetailTabPagesContainer.js
@@ -16,7 +16,7 @@ export const mapStateToProps = state => ({
 });
 
 export const mapDispatchToProps = (dispatch, { match: { params } }) => ({
-  onWillMount: (page) => {
+  onDidMount: (page) => {
     dispatch(fetchReferences(PAGE_REFERENCE_KEY, params.groupname, page));
   },
 });

--- a/test/ui/groups/detail/GroupDetailTabPagesContainer.test.js
+++ b/test/ui/groups/detail/GroupDetailTabPagesContainer.test.js
@@ -41,11 +41,11 @@ describe('GroupDetailTabPagesContainer', () => {
     });
 
     it('should map the correct function properties', () => {
-      expect(props.onWillMount).toBeDefined();
+      expect(props.onDidMount).toBeDefined();
     });
 
-    it('should dispatch an action if onWillMount is called', () => {
-      props.onWillMount();
+    it('should dispatch an action if onDidMount is called', () => {
+      props.onDidMount();
       expect(dispatchMock).toHaveBeenCalledWith('fetchReferences_result');
     });
   });


### PR DESCRIPTION
Change componentWillMount to componentDidMount, which prevents inconsistent rendering order after fetching data.