### PR TITLE
ENG-4362 refactor validations and fix tech debt

### DIFF
--- a/src/ui/common/attributes/AttributeInfo.js
+++ b/src/ui/common/attributes/AttributeInfo.js
@@ -9,7 +9,7 @@ import FormLabel from 'ui/common/form/FormLabel';
 import SwitchRenderer from 'ui/common/form/SwitchRenderer';
 import { MODE_EDIT, MODE_ADD } from 'state/data-types/const';
 
-const maxLength10 = maxLength(10);
+const maxLength15 = maxLength(15);
 const maxLength50 = maxLength(50);
 
 const AttributeInfo = ({ isSearchable, isIndexable, mode }) => {
@@ -65,7 +65,7 @@ const AttributeInfo = ({ isSearchable, isIndexable, mode }) => {
             label={
               <FormLabel labelId="app.code" helpId="app.help.code" required />
           }
-            validate={[required, maxLength10]}
+            validate={[required, maxLength15]}
             disabled={mode === MODE_EDIT}
           />
           <Field

--- a/src/ui/user-profile/common/UserProfileForm.js
+++ b/src/ui/user-profile/common/UserProfileForm.js
@@ -6,7 +6,7 @@ import { Button, Row, Col, FormGroup } from 'patternfly-react';
 import { required } from '@entando/utils';
 import { FormattedMessage, defineMessages, injectIntl, intlShape } from 'react-intl';
 import RenderTextInput from 'ui/common/form/RenderTextInput';
-import UserProfileField, { CompositeField } from 'ui/user-profile/common/UserProfileField';
+import { UserProfileField, CompositeField } from 'ui/user-profile/common/UserProfileField';
 
 import FormLabel from 'ui/common/form/FormLabel';
 import RenderListField from 'ui/common/form/RenderListField';


### PR DESCRIPTION
- Increased `minLength10` to `minLength15` for Profile Type Attribute code size, since `profilepicture` has length of 14 and its a default attribute.
- Replaced `field` renderer with existing `UserProfileField` and deleted repeated code.
- Point 2 fix also fixed the validations that are defined by users for each field for each profile type attributes.

fyi: the other PR was closed as it had incorrect solution