### PR TITLE
ENG-5028 fix error styling

### DIFF
--- a/sass/component-repository/components/BundlePreview.scss
+++ b/sass/component-repository/components/BundlePreview.scss
@@ -76,6 +76,8 @@
 
     &--error {
       margin-bottom: 16px;
+      color: $color-bundle-uninstall-error;
+      font-weight: bold;
     }
   }
 

--- a/src/ui/component-repository/components/item/install-controls/ComponentUninstallStart.js
+++ b/src/ui/component-repository/components/item/install-controls/ComponentUninstallStart.js
@@ -44,7 +44,7 @@ const ComponentUninstallStart = (props) => {
         <div className="BundlePreview__description-title">
           <FormattedMessage id="app.filterTypesSelect.description" />
         </div>
-        <div className="BundlePreview__description-body BundlePreview__description-body--error">
+        <div className="BundlePreview__description-body">
           {description}
         </div>
       </div>


### PR DESCRIPTION
Styling changes were made as asked here: https://entando.myjetbrains.com/youtrack/issue/ENG-5028/when-some-elements-of-the-bundle-have-already-been-deleted-manually-then-the-uninstall-plan-MUST-display-the-modal-a-pertinent#focus=Comments-4-19502.0-0