### PR TITLE
ENG-5017 fix the widget deletion after save as

### DIFF
--- a/src/state/widgets/reducer.js
+++ b/src/state/widgets/reducer.js
@@ -8,7 +8,6 @@ import {
   SET_WIDGETS_TOTAL,
   SET_WIDGET_INFO,
 } from 'state/widgets/types';
-import { getSelectedWidget } from 'state/widgets/selectors';
 
 const list = (state = [], action = {}) => {
   switch (action.type) {
@@ -49,7 +48,7 @@ const selected = (state = null, action = {}) => {
     case REMOVE_WIDGET: {
       const { widgetCode } = action.payload;
       if (!state) return state;
-      const widget = getSelectedWidget(state);
+      const widget = state;
       return widget.code === widgetCode ? null : state;
     }
     default: return state;

--- a/test/state/widgets/reducer.test.js
+++ b/test/state/widgets/reducer.test.js
@@ -66,7 +66,7 @@ describe('state/widget-list/reducer', () => {
 
   describe('after action REMOVE_WIDGET', () => {
     it('should define the new state', () => {
-      state = reducer(state);
+      state = reducer(state, setSelectedWidget({ code: REMOVE_WIDGET }));
       const newState = reducer(state, removeWidget(REMOVE_WIDGET));
       expect(newState.list).not.toEqual(expect.arrayContaining([REMOVE_WIDGET]));
       expect(newState.map).not.toEqual(expect.objectContaining({ REMOVE_WIDGET }));


### PR DESCRIPTION
It was a very very old bug. getSelectedWidget was used incorectly there. `state` is already the selected widget in that function, so no need to call another selector.